### PR TITLE
[BUG] : Setting node name to IP address instead of a FQDN causes intermittent 404 error and truncated node name

### DIFF
--- a/service/node.go
+++ b/service/node.go
@@ -1487,7 +1487,6 @@ func (s *service) addNodeInformationIntoArray(ctx context.Context, array *Storag
 				}
 			}
 		}
-
 		if addNewInitiators {
 			//Modify host operation
 			for _, wwn := range wwns {
@@ -1505,7 +1504,6 @@ func (s *service) addNodeInformationIntoArray(ctx context.Context, array *Storag
 				}
 			}
 		}
-
 		//Check Ip of the host with Host IP Port
 		findHostNamePort := false
 		for _, ipPort := range hostContent.IpPorts {
@@ -1527,7 +1525,7 @@ func (s *service) addNodeInformationIntoArray(ctx context.Context, array *Storag
 				}
 			}
 		}
-
+		var ipFormat = regexp.MustCompile(`(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`)
 		if findHostNamePort == false {
 			//Create Host Ip Port
 			_, err = hostApi.CreateHostIpPort(ctx, hostContent.ID, s.opts.LongNodeName)
@@ -1537,7 +1535,7 @@ func (s *service) addNodeInformationIntoArray(ctx context.Context, array *Storag
 		}
 		for _, nodeIp := range nodeIps {
 			_, err = hostApi.CreateHostIpPort(ctx, hostContent.ID, nodeIp)
-			if err != nil {
+			if err != nil && !ipFormat.MatchString(s.opts.NodeName) {
 				return err
 			}
 		}
@@ -1603,9 +1601,10 @@ func (s *service) addNewNodeToArray(ctx context.Context, array *StorageArrayConf
 	if err != nil {
 		return err
 	}
+	var ipFormat = regexp.MustCompile(`(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`)
 	for _, nodeIp := range nodeIps {
 		_, err = hostApi.CreateHostIpPort(ctx, hostContent.ID, nodeIp)
-		if err != nil {
+		if err != nil && !ipFormat.MatchString(s.opts.NodeName){
 			return err
 		}
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"regexp"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -167,12 +168,21 @@ func (s *service) BeforeServe(
 	if name, ok := csictx.LookupEnv(ctx, gocsi.EnvVarDebug); ok {
 		opts.Debug, _ = strconv.ParseBool(name)
 	}
+
 	if name, ok := csictx.LookupEnv(ctx, EnvNodeName); ok {
 		log.Infof("%s: %s", EnvNodeName, name)
 		opts.LongNodeName = name
-		shortHostName := strings.Split(name, ".")[0]
+		var shortHostName string
+		//check its ip or not
+		var ipFormat = regexp.MustCompile(`(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`)
+		if (ipFormat.MatchString(name)) {
+			shortHostName = name
+		}else{
+			shortHostName = strings.Split(name, ".")[0]
+		}
 		opts.NodeName = shortHostName
 	}
+
 
 	if kubeConfigPath, ok := csictx.LookupEnv(ctx, EnvKubeConfigPath); ok {
 		opts.KubeConfigPath = kubeConfigPath


### PR DESCRIPTION
This PR has the fix for the following customer issue:

- IP address as kubernetes node-name is not compatible to CSI-Unity driver.