### PR TITLE
Added ability associate a tenant with storage volumes

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -26,4 +26,8 @@ const (
 
 	// ParamSyncNodeInfoTimeInterval defines time interval to sync node info
 	ParamSyncNodeInfoTimeInterval = "SYNC_NODE_INFO_TIME_INTERVAL"
+
+	// ParamTenantId defines tenant id to be set while adding host entry 
+	ParamTenantId = "TENANT_ID"
+
 )

--- a/common/constants.go
+++ b/common/constants.go
@@ -27,7 +27,6 @@ const (
 	// ParamSyncNodeInfoTimeInterval defines time interval to sync node info
 	ParamSyncNodeInfoTimeInterval = "SYNC_NODE_INFO_TIME_INTERVAL"
 
-	// ParamTenantId defines tenant id to be set while adding host entry 
-	ParamTenantId = "TENANT_ID"
-
+	// ParamTenantId defines tenant id to be set while adding host entry
+	ParamTenantID = "TENANT_ID"
 )

--- a/common/constants.go
+++ b/common/constants.go
@@ -27,6 +27,6 @@ const (
 	// ParamSyncNodeInfoTimeInterval defines time interval to sync node info
 	ParamSyncNodeInfoTimeInterval = "SYNC_NODE_INFO_TIME_INTERVAL"
 
-	// ParamTenantId defines tenant id to be set while adding host entry
+	// ParamTenantID defines tenant id to be set while adding host entry
 	ParamTenantID = "TENANT_ID"
 )

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/dell/gocsi v1.4.1-0.20211014153731-e18975a3a38c
 	github.com/dell/gofsutil v1.6.0
 	github.com/dell/goiscsi v1.2.0
-	github.com/dell/gounity v1.7.0
+	github.com/dell/gounity v1.7.1-0.20211112123542-63b465d6d635
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/golang/protobuf v1.5.2
 	github.com/kubernetes-csi/csi-lib-utils v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/dell/gofsutil v1.6.0/go.mod h1:98Wpcg7emz4iGgY16fd4MKpnal2SX2hBiwP5gh
 github.com/dell/goiscsi v1.1.0/go.mod h1:MfuMjbKWsh/MOb0VDW20C+LFYRIOfWKGiAxWkeM5TKo=
 github.com/dell/goiscsi v1.2.0 h1:ocQs4pz2Fw2vr73RVAQBKwpN468SK4TZHPLhU7/FB9A=
 github.com/dell/goiscsi v1.2.0/go.mod h1:MfuMjbKWsh/MOb0VDW20C+LFYRIOfWKGiAxWkeM5TKo=
-github.com/dell/gounity v1.7.0 h1:aojJTOXnj6V5axpS0e1ptq1ZzP4zRpJIPAO1ZGdYujk=
-github.com/dell/gounity v1.7.0/go.mod h1:ZFe4e0oPHaN4nF6QLGqxBSGpKETuaGH4WGYGLkSthMU=
+github.com/dell/gounity v1.7.1-0.20211112123542-63b465d6d635 h1:T0iTgmWYsnsytOqfOlupTm77ThO5ONsPs/sF9eJCbic=
+github.com/dell/gounity v1.7.1-0.20211112123542-63b465d6d635/go.mod h1:ZFe4e0oPHaN4nF6QLGqxBSGpKETuaGH4WGYGLkSthMU=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=

--- a/helm/csi-unity/templates/driver-config-params.yaml
+++ b/helm/csi-unity/templates/driver-config-params.yaml
@@ -9,6 +9,7 @@ data:
     ALLOW_RWO_MULTIPOD_ACCESS: "{{ .Values.allowRWOMultiPodAccess }}"
     MAX_UNITY_VOLUMES_PER_NODE: "{{ .Values.maxUnityVolumesPerNode }}"
     SYNC_NODE_INFO_TIME_INTERVAL: "{{ .Values.syncNodeInfoTimeInterval }}"
+    TENANT_ID: "{{ .Values.tenantId }}"
     {{ if .Values.podmon.enabled }}
     PODMON_CONTROLLER_LOG_LEVEL: "debug"
     PODMON_CONTROLLER_LOG_FORMAT: "TEXT"

--- a/helm/csi-unity/values.yaml
+++ b/helm/csi-unity/values.yaml
@@ -139,3 +139,9 @@ allowRWOMultiPodAccess: "false"
 # Default value: 0
 # Examples : 0 , 1
 maxUnityVolumesPerNode: 0
+
+# tenantId - Tenant id that need to added while adding host entry to the array.
+# Allowed values: string
+# Default value: ""
+# Examples : "tenant-2" , "tenant-3"
+tenantId: ""

--- a/service/node.go
+++ b/service/node.go
@@ -1625,12 +1625,12 @@ func (s *service) addNewNodeToArray(ctx context.Context, array *StorageArrayConf
 	unity := array.UnityClient
 
 	// Variable which will be comsumed by hostApi.CreateHost once gounity code change
-	tenant_id := s.opts.TenantId
+	tenantID := s.opts.TenantId
 
 	//Create Host
 
-	hostApi := gounity.NewHost(unity)
-	host, err := hostApi.CreateHost(ctx, s.opts.LongNodeName, tenant_id)
+	hostAPI := gounity.NewHost(unity)
+	host, err := hostAPI.CreateHost(ctx, s.opts.LongNodeName, tenantID)
 
 	if err != nil {
 		return err

--- a/service/node.go
+++ b/service/node.go
@@ -1623,9 +1623,18 @@ func (s *service) addNewNodeToArray(ctx context.Context, array *StorageArrayConf
 	ctx, log, rid := GetRunidLog(ctx)
 	ctx, log = setArrayIDContext(ctx, array.ArrayID)
 	unity := array.UnityClient
+
+	// Variable which will be comsumed by hostApi.CreateHost once gounity code change
+	tenant_id := s.opts.TenantId
+
 	//Create Host
+<<<<<<< HEAD
 	hostAPI := gounity.NewHost(unity)
 	host, err := hostAPI.CreateHost(ctx, s.opts.LongNodeName)
+=======
+	hostApi := gounity.NewHost(unity)
+	host, err := hostApi.CreateHost(ctx, s.opts.LongNodeName, tenant_id)
+>>>>>>> a37451c (added tenant changes)
 	if err != nil {
 		return err
 	}

--- a/service/node.go
+++ b/service/node.go
@@ -1628,13 +1628,10 @@ func (s *service) addNewNodeToArray(ctx context.Context, array *StorageArrayConf
 	tenant_id := s.opts.TenantId
 
 	//Create Host
-<<<<<<< HEAD
-	hostAPI := gounity.NewHost(unity)
-	host, err := hostAPI.CreateHost(ctx, s.opts.LongNodeName)
-=======
+
 	hostApi := gounity.NewHost(unity)
 	host, err := hostApi.CreateHost(ctx, s.opts.LongNodeName, tenant_id)
->>>>>>> a37451c (added tenant changes)
+
 	if err != nil {
 		return err
 	}

--- a/service/node.go
+++ b/service/node.go
@@ -1625,7 +1625,7 @@ func (s *service) addNewNodeToArray(ctx context.Context, array *StorageArrayConf
 	unity := array.UnityClient
 
 	// Variable which will be comsumed by hostApi.CreateHost once gounity code change
-	tenantID := s.opts.TenantId
+	tenantID := s.opts.TenantID
 
 	//Create Host
 

--- a/service/service.go
+++ b/service/service.go
@@ -115,6 +115,8 @@ type Opts struct {
 	KubeConfigPath                string
 	MaxVolumesPerNode             int64
 	LogLevel                      string
+	TenantId                      string
+
 }
 
 type service struct {
@@ -579,6 +581,10 @@ func (s *service) syncDriverConfig(ctx context.Context, v *viper.Viper) {
 
 	if v.IsSet(constants.ParamMaxUnityVolumesPerNode) {
 		s.opts.MaxVolumesPerNode = v.GetInt64(constants.ParamMaxUnityVolumesPerNode)
+	}
+
+	if v.IsSet(constants.ParamTenantId) {
+		s.opts.TenantId = v.GetString(constants.ParamTenantId)
 	}
 
 	if v.IsSet(constants.ParamSyncNodeInfoTimeInterval) {

--- a/service/service.go
+++ b/service/service.go
@@ -115,8 +115,7 @@ type Opts struct {
 	KubeConfigPath                string
 	MaxVolumesPerNode             int64
 	LogLevel                      string
-	TenantId                      string
-
+	TenantID                      string
 }
 
 type service struct {
@@ -583,8 +582,8 @@ func (s *service) syncDriverConfig(ctx context.Context, v *viper.Viper) {
 		s.opts.MaxVolumesPerNode = v.GetInt64(constants.ParamMaxUnityVolumesPerNode)
 	}
 
-	if v.IsSet(constants.ParamTenantId) {
-		s.opts.TenantId = v.GetString(constants.ParamTenantId)
+	if v.IsSet(constants.ParamTenantID) {
+		s.opts.TenantID = v.GetString(constants.ParamTenantID)
 	}
 
 	if v.IsSet(constants.ParamSyncNodeInfoTimeInterval) {


### PR DESCRIPTION
# Description
Unity storage array supports IP Multi-tenancy feature to assign isolated, file-based storage partitions to the NAS servers on a storage processor.
Through this feature implementation in CSI Unity Driver, customers will now be able to associate Tenant with storage volumes.
Additional reference: https://www.dell.com/community/Containers/CSI-dynamic-provisioning-in-a-multitenancy-model/td-p/7476098

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/75 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ran cert-csi automation for unity and runs were successful
- [x] Manually tested installation of CSI driver and creation of pods with tenant enabled
