### PR TITLE
Add support for new access modes in CSISpec 1.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module github.com/dell/csi-unity
 go 1.16
 
 require (
-	github.com/container-storage-interface/spec v1.3.0
+	github.com/container-storage-interface/spec v1.5.0
 	github.com/cucumber/godog v0.10.0
 	github.com/dell/dell-csi-extensions/podmon v1.0.0
 	github.com/dell/gobrick v1.2.0
-	github.com/dell/gocsi v1.3.1
+	github.com/dell/gocsi v1.4.1-0.20211014153731-e18975a3a38c
 	github.com/dell/gofsutil v1.6.0
 	github.com/dell/goiscsi v1.2.0
 	github.com/dell/gounity v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/container-storage-interface/spec v1.1.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
-github.com/container-storage-interface/spec v1.3.0 h1:wMH4UIoWnK/TXYw8mbcIHgZmB6kHOeIsYsiaTJwa6bc=
-github.com/container-storage-interface/spec v1.3.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
+github.com/container-storage-interface/spec v1.5.0 h1:lvKxe3uLgqQeVQcrnL2CPQKISoKjTJxojEs9cBk+HXo=
+github.com/container-storage-interface/spec v1.5.0/go.mod h1:8K96oQNkJ7pFcC2R9Z1ynGGBB1I93kcS6PGg3SsOk8s=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
@@ -78,8 +78,8 @@ github.com/dell/dell-csi-extensions/podmon v1.0.0 h1:QoxioaFfjIP6cJ4s166A1JhgxIX
 github.com/dell/dell-csi-extensions/podmon v1.0.0/go.mod h1:Jjt+zHbLIZ3qJMug17WBYdz7wu90+hd65kgJwv8ZOec=
 github.com/dell/gobrick v1.2.0 h1:dlgWgonXG7qoa+SXlek/NkdFBnfxgqSv+8tsHIBIEDg=
 github.com/dell/gobrick v1.2.0/go.mod h1:pYN9r3XvIjct/QkEg5mEM+k2L3QBLVaHUZeAMzQgwRg=
-github.com/dell/gocsi v1.3.1 h1:YA99j6+kMKiQX/3ERHjKStkAnXWu5sqtk6RE/saMRQk=
-github.com/dell/gocsi v1.3.1/go.mod h1:doJru1XfPHSmROXxtAey6eQ8QseoFKaMtA8YaWCb0mU=
+github.com/dell/gocsi v1.4.1-0.20211014153731-e18975a3a38c h1:aZb2rtCMt5I8T0eNbJ259NmIOroGavUUsp694d/tcBY=
+github.com/dell/gocsi v1.4.1-0.20211014153731-e18975a3a38c/go.mod h1:nIsIXXB5JpAvOQ0//gtPGULC2+NUddpi5qwpBeMhiLs=
 github.com/dell/gofsutil v1.6.0 h1:u5PiMJIyecAWpSlPloov1/3LF5OWrcjJwoFF8dWkjcA=
 github.com/dell/gofsutil v1.6.0/go.mod h1:98Wpcg7emz4iGgY16fd4MKpnal2SX2hBiwP5ghHlvhg=
 github.com/dell/goiscsi v1.1.0/go.mod h1:MfuMjbKWsh/MOb0VDW20C+LFYRIOfWKGiAxWkeM5TKo=

--- a/helm/csi-unity/k8s-1.20-values.yaml
+++ b/helm/csi-unity/k8s-1.20-values.yaml
@@ -8,10 +8,10 @@ images:
 
   # "images.provisioner" defines the container images used for the csi provisioner
   # container.
-  provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+  provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
 
   # "images.snapshotter" defines the container image used for the csi external snapshotter
-  snapshotter: k8s.gcr.io/sig-storage/csi-snapshotter:v4.1.1
+  snapshotter: k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.1
 
   # "images.registrar" defines the container images used for the csi registrar
   # container.
@@ -19,4 +19,4 @@ images:
 
   # "images.resizer" defines the container images used for the csi resizer
   # container.
-  resizer:  k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
+  resizer:  k8s.gcr.io/sig-storage/csi-resizer:v1.3.0

--- a/helm/csi-unity/k8s-1.21-values.yaml
+++ b/helm/csi-unity/k8s-1.21-values.yaml
@@ -8,10 +8,10 @@ images:
 
   # "images.provisioner" defines the container images used for the csi provisioner
   # container.
-  provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+  provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
 
   # "images.snapshotter" defines the container image used for the csi external snapshotter
-  snapshotter: k8s.gcr.io/sig-storage/csi-snapshotter:v4.1.1
+  snapshotter: k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.1
 
   # "images.registrar" defines the container images used for the csi registrar
   # container.
@@ -19,4 +19,4 @@ images:
 
   # "images.resizer" defines the container images used for the csi resizer
   # container.
-  resizer:  k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
+  resizer:  k8s.gcr.io/sig-storage/csi-resizer:v1.3.0

--- a/helm/csi-unity/k8s-1.22-values.yaml
+++ b/helm/csi-unity/k8s-1.22-values.yaml
@@ -8,10 +8,10 @@ images:
 
   # "images.provisioner" defines the container images used for the csi provisioner
   # container.
-  provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+  provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
 
   # "images.snapshotter" defines the container image used for the csi external snapshotter
-  snapshotter: k8s.gcr.io/sig-storage/csi-snapshotter:v4.1.1
+  snapshotter: k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.1
 
   # "images.registrar" defines the container images used for the csi registrar
   # container.
@@ -19,4 +19,4 @@ images:
 
   # "images.resizer" defines the container images used for the csi resizer
   # container.
-  resizer:  k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
+  resizer:  k8s.gcr.io/sig-storage/csi-resizer:v1.3.0

--- a/service/controller.go
+++ b/service/controller.go
@@ -1478,7 +1478,7 @@ func (s *service) exportFilesystem(ctx context.Context, volID, hostID, nodeID, a
 	if foundIncompatible {
 		return nil, status.Error(codes.NotFound, utils.GetMessageWithRunID(rid, "Host: %s has access on NFS Share: %s with incompatible access mode.", nodeID, nfsShareID))
 	}
-	if am.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER && otherHostsWithAccess > 0 {
+	if (am.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER || am.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER || am.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_MULTI_WRITER) && otherHostsWithAccess > 0 {
 		return nil, status.Error(codes.NotFound, utils.GetMessageWithRunID(rid, "Other hosts have access on NFS Share: %s", nfsShareID))
 	}
 	//Idempotent case
@@ -1539,7 +1539,7 @@ func (s *service) exportVolume(ctx context.Context, protocol, volID, hostID, nod
 		if hostAccessID == hostID {
 			log.Debug("Volume has been published to the given host and exists in the required state.")
 			return &csi.ControllerPublishVolumeResponse{PublishContext: pinfo}, nil
-		} else if vc.GetMount() != nil && (am.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER || am.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY) {
+		} else if vc.GetMount() != nil && (am.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER || am.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER || am.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_MULTI_WRITER || am.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY) {
 			return nil, status.Error(codes.Aborted, utils.GetMessageWithRunID(rid, "Volume has been published to a different host already."))
 		}
 		//Gather list of hosts to which the volume is already published to

--- a/service/mount.go
+++ b/service/mount.go
@@ -176,7 +176,7 @@ func publishNFS(ctx context.Context, req *csi.NodePublishVolumeRequest, exportPa
 				} else if m.Path == stagingTargetPath || m.Path == chroot+stagingTargetPath {
 					continue
 				} else {
-					if accMode.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER && !allowRWOmultiPodAccess {
+					if accMode.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER || (accMode.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER && !allowRWOmultiPodAccess) {
 						return status.Error(codes.InvalidArgument, utils.GetMessageWithRunID(rid, "Export path: %s is already mounted to different target path: %s", stageExportPathURL, m.Path))
 					}
 					//For multi-node access modes and when allowRWOmultiPodAccess is true for single-node access, target mount will be executed
@@ -365,7 +365,7 @@ func publishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest, targe
 				return nil
 			} else if m.Path == stagingPath || m.Path == chroot+stagingPath {
 				continue
-			} else if accMode.GetMode() == csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER && !allowRWOmultiPodAccess {
+			} else if accMode.GetMode() == csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER || (accMode.GetMode() == csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER && !allowRWOmultiPodAccess) {
 				//Device has been mounted aleady to another target
 				return status.Error(codes.Internal, utils.GetMessageWithRunID(rid, "device already in use and mounted elsewhere"))
 			}

--- a/service/node.go
+++ b/service/node.go
@@ -391,6 +391,11 @@ func (s *service) NodePublishVolume(
 	if accMode == nil {
 		return nil, status.Error(codes.InvalidArgument, utils.GetMessageWithRunID(rid, "volume access mode required"))
 	}
+	if accMode.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER {
+		s.opts.AllowRWOMultiPodAccess = false
+	} else if accMode.Mode == csi.VolumeCapability_AccessMode_SINGLE_NODE_MULTI_WRITER {
+		s.opts.AllowRWOMultiPodAccess = true
+	}
 
 	if protocol == NFS {
 		//Perform target mount for NFS

--- a/service/validator.go
+++ b/service/validator.go
@@ -84,6 +84,10 @@ func valVolumeCaps(vcs []*csi.VolumeCapability, protocol string) (bool, string) 
 			break
 		case csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER:
 			break
+		case csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER:
+			break
+		case csi.VolumeCapability_AccessMode_SINGLE_NODE_MULTI_WRITER:
+			break
 		case csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY:
 			break
 		case csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY:


### PR DESCRIPTION
# Description
Added support for SINGLE_NODE_SINGLE_WRITER and SINGLE_NODE_MULTI_WRITER

# GitHub Issues
List of GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/76|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- Created PVC with access mode ReadWriteOncePod and verified that only single pod has access to PVC in K8s 1.22
- Created PVC with access mode ReadWriteOnce, allowMultiPodAccess flag set to false and verified that only one pod has access to PVC in K8s 1.22
- Created PVC with access modes ReadWriteOnce, allowMultiPodAccess flag set to true and verified that multiple pods have access to PVC in K8s 1.22
