### PR TITLE
Bug/KRV-1411: tenant with same name is not working in multiarray environment

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -28,5 +28,5 @@ const (
 	ParamSyncNodeInfoTimeInterval = "SYNC_NODE_INFO_TIME_INTERVAL"
 
 	// ParamTenantID defines tenant id to be set while adding host entry
-	ParamTenantID = "TENANT_ID"
+	ParamTenantName = "TENANT_NAME"
 )

--- a/common/constants.go
+++ b/common/constants.go
@@ -27,6 +27,6 @@ const (
 	// ParamSyncNodeInfoTimeInterval defines time interval to sync node info
 	ParamSyncNodeInfoTimeInterval = "SYNC_NODE_INFO_TIME_INTERVAL"
 
-	// ParamTenantID defines tenant id to be set while adding host entry
+	// ParamTenantName defines tenant name to be set while adding host entry
 	ParamTenantName = "TENANT_NAME"
 )

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/dell/gocsi v1.4.1-0.20211014153731-e18975a3a38c
 	github.com/dell/gofsutil v1.6.0
 	github.com/dell/goiscsi v1.2.0
-	github.com/dell/gounity v1.7.1-0.20211112123542-63b465d6d635
+	github.com/dell/gounity v1.7.1-0.20211116121253-a4fd4c0f2898
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/golang/protobuf v1.5.2
 	github.com/kubernetes-csi/csi-lib-utils v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,8 @@ github.com/dell/gofsutil v1.6.0/go.mod h1:98Wpcg7emz4iGgY16fd4MKpnal2SX2hBiwP5gh
 github.com/dell/goiscsi v1.1.0/go.mod h1:MfuMjbKWsh/MOb0VDW20C+LFYRIOfWKGiAxWkeM5TKo=
 github.com/dell/goiscsi v1.2.0 h1:ocQs4pz2Fw2vr73RVAQBKwpN468SK4TZHPLhU7/FB9A=
 github.com/dell/goiscsi v1.2.0/go.mod h1:MfuMjbKWsh/MOb0VDW20C+LFYRIOfWKGiAxWkeM5TKo=
-github.com/dell/gounity v1.7.1-0.20211112123542-63b465d6d635 h1:T0iTgmWYsnsytOqfOlupTm77ThO5ONsPs/sF9eJCbic=
-github.com/dell/gounity v1.7.1-0.20211112123542-63b465d6d635/go.mod h1:ZFe4e0oPHaN4nF6QLGqxBSGpKETuaGH4WGYGLkSthMU=
+github.com/dell/gounity v1.7.1-0.20211116121253-a4fd4c0f2898 h1:Ka9wMhOGksN3xmRvoH1H/namEl267P6A0THjgc0Tgb8=
+github.com/dell/gounity v1.7.1-0.20211116121253-a4fd4c0f2898/go.mod h1:ZFe4e0oPHaN4nF6QLGqxBSGpKETuaGH4WGYGLkSthMU=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=

--- a/helm/csi-unity/templates/driver-config-params.yaml
+++ b/helm/csi-unity/templates/driver-config-params.yaml
@@ -9,7 +9,7 @@ data:
     ALLOW_RWO_MULTIPOD_ACCESS: "{{ .Values.allowRWOMultiPodAccess }}"
     MAX_UNITY_VOLUMES_PER_NODE: "{{ .Values.maxUnityVolumesPerNode }}"
     SYNC_NODE_INFO_TIME_INTERVAL: "{{ .Values.syncNodeInfoTimeInterval }}"
-    TENANT_ID: "{{ .Values.tenantId }}"
+    TENANT_NAME: "{{ .Values.tenantName }}"
     {{ if .Values.podmon.enabled }}
     PODMON_CONTROLLER_LOG_LEVEL: "debug"
     PODMON_CONTROLLER_LOG_FORMAT: "TEXT"

--- a/helm/csi-unity/values.yaml
+++ b/helm/csi-unity/values.yaml
@@ -140,8 +140,8 @@ allowRWOMultiPodAccess: "false"
 # Examples : 0 , 1
 maxUnityVolumesPerNode: 0
 
-# tenantId - Tenant id that need to added while adding host entry to the array.
+# tenantName - Tenant name that need to added while adding host entry to the array.
 # Allowed values: string
 # Default value: ""
-# Examples : "tenant-2" , "tenant-3"
-tenantId: ""
+# Examples : "tenant2" , "tenant3"
+tenantName: ""

--- a/service/node.go
+++ b/service/node.go
@@ -1750,16 +1750,16 @@ func (s *service) addNewNodeToArray(ctx context.Context, array *StorageArrayConf
 
 	tenantName := s.opts.TenantName
 	var tenantID string
-	
+
 	//Create Host
 	hostAPI := gounity.NewHost(unity)
-	
+
 	// get tenantid from tenant name
 	tenants, err := hostAPI.FindTenants(ctx)
 	for eachtenant := range tenants.Entries {
-			if tenants.Entries[eachtenant].Content.Name == tenantName{
-				tenantID = tenants.Entries[eachtenant].Content.Id
-        }
+		if tenants.Entries[eachtenant].Content.Name == tenantName {
+			tenantID = tenants.Entries[eachtenant].Content.Id
+		}
 	}
 
 	host, err := hostAPI.CreateHost(ctx, s.opts.LongNodeName, tenantID)

--- a/service/node.go
+++ b/service/node.go
@@ -1748,13 +1748,13 @@ func (s *service) addNewNodeToArray(ctx context.Context, array *StorageArrayConf
 	ctx, log = setArrayIDContext(ctx, array.ArrayID)
 	unity := array.UnityClient
 
-	// Variable which will be comsumed by hostApi.CreateHost once gounity code change
 	tenantName := s.opts.TenantName
 	var tenantID string
 
 	//Create Host
-
 	hostAPI := gounity.NewHost(unity)
+	
+	// get tenantid from tenant name
 	tenants, err:= hostAPI.FindTenants(ctx)
 	for eachtenant := range tenants.Entries {
         if tenants.Entries[eachtenant].Content.Name == tenantName{

--- a/service/node.go
+++ b/service/node.go
@@ -1750,15 +1750,15 @@ func (s *service) addNewNodeToArray(ctx context.Context, array *StorageArrayConf
 
 	tenantName := s.opts.TenantName
 	var tenantID string
-
+	
 	//Create Host
 	hostAPI := gounity.NewHost(unity)
 	
 	// get tenantid from tenant name
-	tenants, err:= hostAPI.FindTenants(ctx)
+	tenants, err := hostAPI.FindTenants(ctx)
 	for eachtenant := range tenants.Entries {
-        if tenants.Entries[eachtenant].Content.Name == tenantName{
-            tenantID = tenants.Entries[eachtenant].Content.Id
+			if tenants.Entries[eachtenant].Content.Name == tenantName{
+				tenantID = tenants.Entries[eachtenant].Content.Id
         }
 	}
 

--- a/service/node.go
+++ b/service/node.go
@@ -1757,8 +1757,8 @@ func (s *service) addNewNodeToArray(ctx context.Context, array *StorageArrayConf
 	tenants, err:= hostAPI.FindTenants(ctx)
 	for eachtenant := range tenants.Entries {
         if tenants.Entries[eachtenant].Content.Name == s.opts.TenantName{
-            tenantID := tenants.Entries[i].Content.Id
-            log.Debugf("tenant details: %s ", t.Entries[i].Content.Name)
+            tenantID := tenants.Entries[eachtenant].Content.Id
+            log.Debugf("tenant details: %s ", t.Entries[eachtenant].Content.Name)
         }
 	host, err := hostAPI.CreateHost(ctx, s.opts.LongNodeName, tenantID)
 

--- a/service/node.go
+++ b/service/node.go
@@ -1760,6 +1760,7 @@ func (s *service) addNewNodeToArray(ctx context.Context, array *StorageArrayConf
             tenantID := tenants.Entries[eachtenant].Content.Id
             log.Debugf("tenant details: %s ", t.Entries[eachtenant].Content.Name)
         }
+	}
 	host, err := hostAPI.CreateHost(ctx, s.opts.LongNodeName, tenantID)
 
 	if err != nil {

--- a/service/node.go
+++ b/service/node.go
@@ -1758,7 +1758,7 @@ func (s *service) addNewNodeToArray(ctx context.Context, array *StorageArrayConf
 	tenants, err:= hostAPI.FindTenants(ctx)
 	for eachtenant := range tenants.Entries {
         if tenants.Entries[eachtenant].Content.Name == tenantName{
-            tenantID := tenants.Entries[eachtenant].Content.Id
+            tenantID = tenants.Entries[eachtenant].Content.Id
             log.Debugf("tenant details: %s ", tenants.Entries[eachtenant].Content.Name)
         }
 	}

--- a/service/node.go
+++ b/service/node.go
@@ -1759,7 +1759,6 @@ func (s *service) addNewNodeToArray(ctx context.Context, array *StorageArrayConf
 	for eachtenant := range tenants.Entries {
         if tenants.Entries[eachtenant].Content.Name == tenantName{
             tenantID = tenants.Entries[eachtenant].Content.Id
-            log.Debugf("tenant details: %s ", tenants.Entries[eachtenant].Content.Name)
         }
 	}
 

--- a/service/node.go
+++ b/service/node.go
@@ -1750,6 +1750,7 @@ func (s *service) addNewNodeToArray(ctx context.Context, array *StorageArrayConf
 
 	// Variable which will be comsumed by hostApi.CreateHost once gounity code change
 	tenantName := s.opts.TenantName
+	var tenantID string
 
 	//Create Host
 
@@ -1758,7 +1759,7 @@ func (s *service) addNewNodeToArray(ctx context.Context, array *StorageArrayConf
 	for eachtenant := range tenants.Entries {
         if tenants.Entries[eachtenant].Content.Name == s.opts.TenantName{
             tenantID := tenants.Entries[eachtenant].Content.Id
-            log.Debugf("tenant details: %s ", t.Entries[eachtenant].Content.Name)
+            log.Debugf("tenant details: %s ", tenants.Entries[eachtenant].Content.Name)
         }
 	}
 	host, err := hostAPI.CreateHost(ctx, s.opts.LongNodeName, tenantID)

--- a/service/node.go
+++ b/service/node.go
@@ -1757,11 +1757,12 @@ func (s *service) addNewNodeToArray(ctx context.Context, array *StorageArrayConf
 	hostAPI := gounity.NewHost(unity)
 	tenants, err:= hostAPI.FindTenants(ctx)
 	for eachtenant := range tenants.Entries {
-        if tenants.Entries[eachtenant].Content.Name == s.opts.TenantName{
+        if tenants.Entries[eachtenant].Content.Name == tenantName{
             tenantID := tenants.Entries[eachtenant].Content.Id
             log.Debugf("tenant details: %s ", tenants.Entries[eachtenant].Content.Name)
         }
 	}
+
 	host, err := hostAPI.CreateHost(ctx, s.opts.LongNodeName, tenantID)
 
 	if err != nil {

--- a/service/node.go
+++ b/service/node.go
@@ -1749,11 +1749,17 @@ func (s *service) addNewNodeToArray(ctx context.Context, array *StorageArrayConf
 	unity := array.UnityClient
 
 	// Variable which will be comsumed by hostApi.CreateHost once gounity code change
-	tenantID := s.opts.TenantID
+	tenantName := s.opts.TenantName
 
 	//Create Host
 
 	hostAPI := gounity.NewHost(unity)
+	tenants, err:= hostAPI.FindTenants(ctx)
+	for eachtenant := range tenants.Entries {
+        if tenants.Entries[eachtenant].Content.Name == s.opts.TenantName{
+            tenantID := tenants.Entries[i].Content.Id
+            log.Debugf("tenant details: %s ", t.Entries[i].Content.Name)
+        }
 	host, err := hostAPI.CreateHost(ctx, s.opts.LongNodeName, tenantID)
 
 	if err != nil {

--- a/service/service.go
+++ b/service/service.go
@@ -115,7 +115,7 @@ type Opts struct {
 	KubeConfigPath                string
 	MaxVolumesPerNode             int64
 	LogLevel                      string
-	TenantID                      string
+	TenantName                    string
 }
 
 type service struct {
@@ -582,8 +582,8 @@ func (s *service) syncDriverConfig(ctx context.Context, v *viper.Viper) {
 		s.opts.MaxVolumesPerNode = v.GetInt64(constants.ParamMaxUnityVolumesPerNode)
 	}
 
-	if v.IsSet(constants.ParamTenantID) {
-		s.opts.TenantID = v.GetString(constants.ParamTenantID)
+	if v.IsSet(constants.ParamTenantName) {
+		s.opts.TenantName = v.GetString(constants.ParamTenantName)
 	}
 
 	if v.IsSet(constants.ParamSyncNodeInfoTimeInterval) {


### PR DESCRIPTION
# Description
bug fix for tenant with same name is not working in multiarray environment



# Checklist:

- [x ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] Backward compatibility is not broken

# How Has This Been Tested?
myvalues :
![3](https://user-images.githubusercontent.com/92289639/141922378-702ea096-7a40-44ab-b8aa-0fe4f2aac422.PNG)

tenant logs :
![2](https://user-images.githubusercontent.com/92289639/141922396-d9d49bea-5ef1-48b2-b002-782a75e0f960.PNG)

tenant added in unity array :
![1](https://user-images.githubusercontent.com/92289639/141922404-47a021e7-05c9-44f1-921e-6e1748dd2fb0.PNG)


