### PR TITLE
Bug/KRV-1495: Invalid tenant name doesn't fail node registration

### DIFF
--- a/service/node.go
+++ b/service/node.go
@@ -1766,14 +1766,13 @@ func (s *service) addNewNodeToArray(ctx context.Context, array *StorageArrayConf
 	if tenantName != "" && tenantID == "" {
 		return status.Error(codes.Internal, utils.GetMessageWithRunID(rid, "Please enter Valid tenant Name : %s", tenantName))
 
-	} else {
-		host, err := hostAPI.CreateHost(ctx, s.opts.LongNodeName, tenantID)
-		if err != nil {
-			return err
-		}
-		hostContent = host.HostContent
-		log.Debugf("New Host Id: %s", hostContent.ID)
 	}
+	host, err := hostAPI.CreateHost(ctx, s.opts.LongNodeName, tenantID)
+	if err != nil {
+		return err
+	}
+	hostContent = host.HostContent
+	log.Debugf("New Host Id: %s", hostContent.ID)
 
 	//Create Host Ip Port
 	_, err = hostAPI.CreateHostIpPort(ctx, hostContent.ID, s.opts.LongNodeName)

--- a/service/node.go
+++ b/service/node.go
@@ -1762,13 +1762,18 @@ func (s *service) addNewNodeToArray(ctx context.Context, array *StorageArrayConf
 		}
 	}
 
-	host, err := hostAPI.CreateHost(ctx, s.opts.LongNodeName, tenantID)
+	var hostContent types.HostContent
+	if tenantName != "" && tenantID == "" {
+		return status.Error(codes.Internal, utils.GetMessageWithRunID(rid, "Please enter Valid tenant Name : %s", tenantName))
 
-	if err != nil {
-		return err
+	}else{
+		host, err := hostAPI.CreateHost(ctx, s.opts.LongNodeName, tenantID)
+		if err != nil {
+			return err
+		}
+		hostContent = host.HostContent
+		log.Debugf("New Host Id: %s", hostContent.ID)
 	}
-	hostContent := host.HostContent
-	log.Debugf("New Host Id: %s", hostContent.ID)
 
 	//Create Host Ip Port
 	_, err = hostAPI.CreateHostIpPort(ctx, hostContent.ID, s.opts.LongNodeName)

--- a/service/node.go
+++ b/service/node.go
@@ -1766,7 +1766,7 @@ func (s *service) addNewNodeToArray(ctx context.Context, array *StorageArrayConf
 	if tenantName != "" && tenantID == "" {
 		return status.Error(codes.Internal, utils.GetMessageWithRunID(rid, "Please enter Valid tenant Name : %s", tenantName))
 
-	}else{
+	} else {
 		host, err := hostAPI.CreateHost(ctx, s.opts.LongNodeName, tenantID)
 		if err != nil {
 			return err


### PR DESCRIPTION
# Description
Invalid tenant name doesn't fail node registration

# GitHub Issues
KRV-1411



# Checklist:

- [ x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] Backward compatibility is not broken

# How Has This Been Tested?
Throws proper error  when wrong tenant name is passed
![image (2)](https://user-images.githubusercontent.com/92289639/142219276-e42b0e01-3331-4cc9-b823-1f1899ab85b8.png)


