### PR TITLE
Fix for sidecar installation failure if k8s worker nodes are not in ~/.ssh/known_hosts

### DIFF
--- a/dell-csi-helm-installer/csi-install.sh
+++ b/dell-csi-helm-installer/csi-install.sh
@@ -147,8 +147,6 @@ function install_driver() {
   HELMOUTPUT="/tmp/csi-install.$$.out"
   run_command helm ${1} \
     --set openshift=${OPENSHIFT} \
-    --values "${DRIVERDIR}/${DRIVER}/k8s-${kMajorVersion}.${kMinorVersion}-values.yaml" \
-    --values "${DRIVERDIR}/${DRIVER}/driver-image.yaml" \
     --values "${VALUES}" \
     --namespace ${NS} "${RELEASE}" \
     "${DRIVERDIR}/${DRIVER}" >"${HELMOUTPUT}" 2>&1

--- a/dell-csi-helm-installer/csi-install.sh
+++ b/dell-csi-helm-installer/csi-install.sh
@@ -15,7 +15,7 @@ PROG="${0}"
 NODE_VERIFY=1
 VERIFY=1
 MODE="install"
-DEFAULT_DRIVER_VERSION="2.0.0"
+DEFAULT_DRIVER_VERSION="2.2.0"
 WATCHLIST=""
 
 # export the name of the debug log, so child processes will see it

--- a/dell-csi-helm-installer/csi-install.sh
+++ b/dell-csi-helm-installer/csi-install.sh
@@ -15,7 +15,7 @@ PROG="${0}"
 NODE_VERIFY=1
 VERIFY=1
 MODE="install"
-DEFAULT_DRIVER_VERSION="2.2.0"
+DEFAULT_DRIVER_VERSION="2.0.0"
 WATCHLIST=""
 
 # export the name of the debug log, so child processes will see it
@@ -147,6 +147,8 @@ function install_driver() {
   HELMOUTPUT="/tmp/csi-install.$$.out"
   run_command helm ${1} \
     --set openshift=${OPENSHIFT} \
+    --values "${DRIVERDIR}/${DRIVER}/k8s-${kMajorVersion}.${kMinorVersion}-values.yaml" \
+    --values "${DRIVERDIR}/${DRIVER}/driver-image.yaml" \
     --values "${VALUES}" \
     --namespace ${NS} "${RELEASE}" \
     "${DRIVERDIR}/${DRIVER}" >"${HELMOUTPUT}" 2>&1

--- a/dell-csi-helm-installer/verify.sh
+++ b/dell-csi-helm-installer/verify.sh
@@ -370,15 +370,24 @@ function verify_authorization_proxy_server() {
     WGET=$(ssh ${NODEUSER}@"${node}" "which wget")
     if [ -x "${WGET}" ]; then
       log info "Running wget on "${node}""
+      nr=1
       if [ "${insecure}" == "true" ]
       then
         resp=$(ssh ${NODEUSER}@"${node}" wget --no-check-certificate --server-response --spider --quiet https://"${proxyHost}" 2>&1)
         log info "${resp}"
-        code=$(echo "${resp}" | awk 'NR==1{print $2}')
+        if [ "${resp}" == "Warning"* ]
+        then
+          nr=2
+        fi
+        code=$(echo "${resp}" | awk -v var=$nr 'NR==var {print $2}')
       else
         resp=$(ssh ${NODEUSER}@"${node}" wget --server-response --spider --quiet https://"${proxyHost}" 2>&1)
         log info "${resp}"
-        code=$(echo "${resp}" | awk 'NR==1{print $2}')
+        if [ "${resp}" == "Warning"* ]
+        then
+          nr=2
+        fi
+        code=$(echo "${resp}" | awk -v var=$nr 'NR==var {print $2}')
       fi
 
       if [ "${code}" != "502" ]; then


### PR DESCRIPTION
# Description
This PR addresses an issue with sidecar installation failure when the remote k8s worker nodes have not yet been added to the ~/.ssh/known_hosts file. While running SSH commands to check connectivity to the authorization proxy there is an additional message in the response "Warning: Permanently added '1.2.3.4' (ECDSA) to the list of known hosts.". This PR adds changes to ignore this warning message to get the response code in the next line.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/147 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
