### PR TITLE
KRV-2816 : documentation in values.yaml toleration for running on master node incorrect

### DIFF
--- a/helm/csi-unity/values.yaml
+++ b/helm/csi-unity/values.yaml
@@ -76,11 +76,11 @@ controller:
   nodeSelector:
 
   # tolerations: Define tolerations for the controllers, if required.
+  # Leave as blank to install controller on worker nodes
   # Default value: None
   tolerations:
   #  - key: "node-role.kubernetes.io/master"
-  #    operator: "Equal"
-  #    value: "true"
+  #    operator: "Exists"
   #    effect: "NoSchedule"
 
   volumeHealthMonitor:


### PR DESCRIPTION
# Description
documentation in values.yaml toleration for running on master node incorrect

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/128 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
master is tainted as shown bellow :
<img width="529" alt="taint in master" src="https://user-images.githubusercontent.com/92289639/153190741-a32d9cf2-be82-4027-ae2d-9474a0863ffa.PNG">

1. Installation of pod on master without toleration  defined in myvalues.yaml and pods are not scheduled as expected : 
     
<img width="753" alt="without toleratiorn and only taint in master" src="https://user-images.githubusercontent.com/92289639/153191027-3fb5d719-516b-4617-be21-4c8074c9af9c.PNG">

  and corresponding muvalues:
 
<img width="386" alt="myvalues without toleratiorn and  taint in master" src="https://user-images.githubusercontent.com/92289639/153191123-232d2638-9800-4b52-bb13-267a10c0e6d9.PNG">

2. Installation of pod on master with toleration defined in myvalues.yaml and pods are  scheduled as expected: 

<img width="752" alt="with toleratiorn and  taint in master" src="https://user-images.githubusercontent.com/92289639/153191270-4336a17e-f2bf-4a8e-8da3-43b62a9f6d4f.PNG">

<img width="508" alt="myvalues withtoleratiorn and  taint in master" src="https://user-images.githubusercontent.com/92289639/153191286-aa6d1968-50ba-4513-b7c4-09fa474acb1d.PNG">
