### PR TITLE
Add CSM Podmon image & use the same loglevel as the driver

### DIFF
--- a/helm/csi-unity/templates/driver-config-params.yaml
+++ b/helm/csi-unity/templates/driver-config-params.yaml
@@ -11,8 +11,8 @@ data:
     SYNC_NODE_INFO_TIME_INTERVAL: "{{ .Values.syncNodeInfoInterval }}"
     TENANT_NAME: "{{ .Values.tenantName }}"
     {{ if .Values.podmon.enabled }}
-    PODMON_CONTROLLER_LOG_LEVEL: "debug"
+    PODMON_CONTROLLER_LOG_LEVEL: "{{ .Values.logLevel }}"
     PODMON_CONTROLLER_LOG_FORMAT: "TEXT"
-    PODMON_NODE_LOG_LEVEL: "debug"
+    PODMON_NODE_LOG_LEVEL: "{{ .Values.logLevel }}"
     PODMON_NODE_LOG_FORMAT: "TEXT"
     {{ end }}

--- a/helm/csi-unity/values.yaml
+++ b/helm/csi-unity/values.yaml
@@ -126,7 +126,7 @@ podmon:
   # allowed values - string
   # default value : None
   # Example : "podman:latest", "pod:latest"
-  image:
+  image: dellemc/podmon:v1.0.1
 #  controller:
 #    args:
 #      - "--csisock=unix:/var/run/csi/csi.sock"


### PR DESCRIPTION
# Description
Add link to the podmon image and use the same loglevel as the driver.
`debug` might be too high for production environment by default

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
This was tested in context of CSI PowerFlex here : https://github.com/dell/csi-powerflex/pull/72
Applying the same changes