### PR TITLE
KRV-2701 : csi-unity sample storageclass documentation needs improvement

### DIFF
--- a/samples/storageclass/unity-fc.yaml
+++ b/samples/storageclass/unity-fc.yaml
@@ -56,7 +56,7 @@ parameters:
   # Optional: false
   # Examples: "APM000000001", "APM000000002"
   arrayId: <ARRAY_ID>
-  #storagePool - Define Storage pool CLI Id of the storage array.
+  #storagePool - Defines Storage pool, the value from the storage array GUI Pools column labeled "CLI ID".
   # Allowed values: String
   # Default value: None
   # Optional: false
@@ -71,16 +71,22 @@ parameters:
   thinProvisioned: true 
   #isDataReductionEnabled - Defines Boolean to choose value of is DataReductionEnabled while creating a new volume
   # Allowed values: 
-  #    true      - to enable data reduction
-  #    false     - to disable data reduction
+  #    true      - to enable data reduction for all-flash storage pool.
+  #    false     - to disable data reduction for any storage pool.
   # Optional: true
   # Default value: false
   isDataReductionEnabled: true
-  #tieringPolicy - Define Tiering policy that is to be used for provisioning
+  #TieringPolicy - Tiering policy to be used during provisioning
+  #                Requires FAST VP license.
   # Allowed values: String
   # Optional: true
-  # Default value: None
   # Examples: "0"
+  # Default value: None
+  # Accepted values:
+  #   "0" for "Start High Then Auto-Tier"
+  #   "1" for "Auto-Tier"
+  #   "2" for "Highest Available Tier"
+  #   "3" for "Lowest Available Tier"
   tieringPolicy: <TIERING_POLICY>
   # hostIOLimitName- Insert Host IO Limit Name that is to be used for provisioning here. 
   # Allowed values: String
@@ -92,13 +98,15 @@ parameters:
 # Allowed values: map of key-value pairs
 # Optional: false
 # Default value: None
+# Examples: "apm0020280XXXX" , "apm0021340XXXX"
+# Here first three characters  should be in small letters.
 allowedTopologies:
   - matchLabelExpressions:
       - key: csi-unity.dellemc.com/<array_id>-fc
         values:
           - "true"
-# mountOptions - Defines mount input vlaues
+# mountOptions - Defines mount input values
+# Default value: []
 # Optional: false
-# Default value: None
-# Examples: "/dev/sdc", "/dev/unity"        
+# Examples: "hard" mount with NFS , "context" mount for block storage
 mountOptions: ["<mountOption1>", "<mountOption2>", ..., "<mountOptionN>"]

--- a/samples/storageclass/unity-fc.yaml
+++ b/samples/storageclass/unity-fc.yaml
@@ -56,7 +56,7 @@ parameters:
   # Optional: false
   # Examples: "APM000000001", "APM000000002"
   arrayId: <ARRAY_ID>
-  #storagePool - Defines the value from Pools which should be picked from the column labeled "CLI ID"  in the storage array GUI.
+  #storagePool - Defines storage pool. The value should be picked from the column labeled "CLI ID" of Pools in the Unisphere GUI.
   # Allowed values: String
   # Default value: None
   # Optional: false
@@ -108,6 +108,7 @@ allowedTopologies:
 # mountOptions - Defines mount input values.
 # Default value: []
 # Optional: false
-# Examples: "hard"    - option for mounting with NFS
-#           "context" - option for mounting with block storage
+# Examples:
+#   "hard"    - option for mounting with NFS
+#   "context" - option for mounting with block storage
 mountOptions: ["<mountOption1>", "<mountOption2>", ..., "<mountOptionN>"]

--- a/samples/storageclass/unity-fc.yaml
+++ b/samples/storageclass/unity-fc.yaml
@@ -56,7 +56,7 @@ parameters:
   # Optional: false
   # Examples: "APM000000001", "APM000000002"
   arrayId: <ARRAY_ID>
-  #storagePool - Defines Storage pool, the value from the storage array GUI Pools column labeled "CLI ID".
+  #storagePool - Defines the value from Pools which should be picked from the column labeled "CLI ID"  in the storage array GUI.
   # Allowed values: String
   # Default value: None
   # Optional: false
@@ -71,8 +71,8 @@ parameters:
   thinProvisioned: true 
   #isDataReductionEnabled - Defines Boolean to choose value of is DataReductionEnabled while creating a new volume
   # Allowed values: 
-  #    true      - to enable data reduction for all-flash storage pool.
-  #    false     - to disable data reduction for any storage pool.
+  #    true      - Enables data reduction for all-flash storage pool.
+  #    false     - Disables data reduction.
   # Optional: true
   # Default value: false
   isDataReductionEnabled: true
@@ -105,8 +105,9 @@ allowedTopologies:
       - key: csi-unity.dellemc.com/<array_id>-fc
         values:
           - "true"
-# mountOptions - Defines mount input values
+# mountOptions - Defines mount input values.
 # Default value: []
 # Optional: false
-# Examples: "hard" mount with NFS , "context" mount for block storage
+# Examples: "hard"    - option for mounting with NFS
+#           "context" - option for mounting with block storage
 mountOptions: ["<mountOption1>", "<mountOption2>", ..., "<mountOptionN>"]

--- a/samples/storageclass/unity-iscsi.yaml
+++ b/samples/storageclass/unity-iscsi.yaml
@@ -50,13 +50,13 @@ parameters:
   # Default value: ""
   # Optional: false
   protocol: iSCSI 
-    # arrayId - Serial Id of the array that will be used for provisioning.
+  # arrayId - Serial Id of the array that will be used for provisioning.
   # Allowed values: String
   # Default value: None
   # Optional: false
   # Examples: "APM000000001", "APM000000002"
   arrayId: <ARRAY_ID>
-  #storagePool - Define Storage pool CLI Id of the storage array.
+  #storagePool - Defines Storage pool, the value from the storage array GUI Pools column labeled "CLI ID".
   # Allowed values: String
   # Default value: None
   # Optional: false
@@ -71,16 +71,22 @@ parameters:
   thinProvisioned: true
   #isDataReductionEnabled - Defines Boolean to choose value of is DataReductionEnabled while creating a new volume
   # Allowed values: 
-  #    true      - to enable data reduction
-  #    false     - to disable data reduction
+  #    true      - to enable data reduction for all-flash storage pool.
+  #    false     - to disable data reduction for any storage pool.
   # Default value: false
   # Optional: true
   isDataReductionEnabled: true
-  #tieringPolicy - Define Tiering policy that is to be used for provisioning
+  #TieringPolicy - Tiering policy to be used during provisioning
+  #                Requires FAST VP license.
   # Allowed values: String
-  # Default value: None
   # Optional: true
   # Examples: "0"
+  # Default value: None
+  # Accepted values:
+  #   "0" for "Start High Then Auto-Tier"
+  #   "1" for "Auto-Tier"
+  #   "2" for "Highest Available Tier"
+  #   "3" for "Lowest Available Tier"
   tieringPolicy: <TIERING_POLICY> 
   # hostIOLimitName- Insert Host IO Limit Name that is to be used for provisioning here. 
   # Allowed values: String
@@ -92,13 +98,15 @@ parameters:
 # Allowed values: map of key-value pairs
 # Default value: None
 # Optional: false
+# Examples: "apm0020280XXXX" , "apm0021340XXXX"
+# Here first three characters  should be in small letters.
 allowedTopologies:
   - matchLabelExpressions:
       - key: csi-unity.dellemc.com/<array_id>-iscsi
         values:
           - "true"
-# mountOptions - Defines mount input vlaues
-# Default value: None
+# mountOptions - Defines mount input values
+# Default value: []
 # Optional: false
-# Examples: "/dev/sdc", "/dev/unity"               
+# Examples: "hard" mount with NFS , "context" mount for block storage
 mountOptions: ["<mountOption1>", "<mountOption2>", ..., "<mountOptionN>"]

--- a/samples/storageclass/unity-iscsi.yaml
+++ b/samples/storageclass/unity-iscsi.yaml
@@ -56,7 +56,7 @@ parameters:
   # Optional: false
   # Examples: "APM000000001", "APM000000002"
   arrayId: <ARRAY_ID>
-  #storagePool - Defines the value from Pools which should be picked from the column labeled "CLI ID"  in the storage array GUI.
+  #storagePool - Defines storage pool. The value should be picked from the column labeled "CLI ID" of Pools in the Unisphere GUI.
   # Allowed values: String
   # Default value: None
   # Optional: false
@@ -108,6 +108,7 @@ allowedTopologies:
 # mountOptions - Defines mount input values.
 # Default value: []
 # Optional: false
-# Examples: "hard"    - option for mounting with NFS
-#           "context" - option for mounting with block storage
+# Examples:
+#   "hard"    - option for mounting with NFS
+#   "context" - option for mounting with block storage
 mountOptions: ["<mountOption1>", "<mountOption2>", ..., "<mountOptionN>"]

--- a/samples/storageclass/unity-iscsi.yaml
+++ b/samples/storageclass/unity-iscsi.yaml
@@ -56,7 +56,7 @@ parameters:
   # Optional: false
   # Examples: "APM000000001", "APM000000002"
   arrayId: <ARRAY_ID>
-  #storagePool - Defines Storage pool, the value from the storage array GUI Pools column labeled "CLI ID".
+  #storagePool - Defines the value from Pools which should be picked from the column labeled "CLI ID"  in the storage array GUI.
   # Allowed values: String
   # Default value: None
   # Optional: false
@@ -71,10 +71,10 @@ parameters:
   thinProvisioned: true
   #isDataReductionEnabled - Defines Boolean to choose value of is DataReductionEnabled while creating a new volume
   # Allowed values: 
-  #    true      - to enable data reduction for all-flash storage pool.
-  #    false     - to disable data reduction for any storage pool.
-  # Default value: false
+  #    true      - Enables data reduction for all-flash storage pool.
+  #    false     - Disables data reduction.
   # Optional: true
+  # Default value: false
   isDataReductionEnabled: true
   #TieringPolicy - Tiering policy to be used during provisioning
   #                Requires FAST VP license.
@@ -105,8 +105,9 @@ allowedTopologies:
       - key: csi-unity.dellemc.com/<array_id>-iscsi
         values:
           - "true"
-# mountOptions - Defines mount input values
+# mountOptions - Defines mount input values.
 # Default value: []
 # Optional: false
-# Examples: "hard" mount with NFS , "context" mount for block storage
+# Examples: "hard"    - option for mounting with NFS
+#           "context" - option for mounting with block storage
 mountOptions: ["<mountOption1>", "<mountOption2>", ..., "<mountOptionN>"]

--- a/samples/storageclass/unity-nfs.yaml
+++ b/samples/storageclass/unity-nfs.yaml
@@ -53,7 +53,7 @@ parameters:
   # Default value: None
   # Examples: "APM000000001", "APM000000002"
   arrayId: <ARRAY_ID>
-  #storagePool - Defines Storage pool, the value from the storage array GUI Pools column labeled "CLI ID".
+  #storagePool - Defines the value from Pools which should be picked from the column labeled "CLI ID"  in the storage array GUI.
   # Allowed values: String
   # Default value: None
   # Optional: false
@@ -68,10 +68,10 @@ parameters:
   thinProvisioned: true
   #isDataReductionEnabled - Defines Boolean to choose value of is DataReductionEnabled while creating a new volume
   # Allowed values: 
-  #    true      - to enable data reduction for all-flash storage pool.
-  #    false     - to disable data reduction for any storage pool.
-  # Default value: false
+  #    true      - Enables data reduction for all-flash storage pool.
+  #    false     - Disables data reduction.
   # Optional: true
+  # Default value: false
   isDataReductionEnabled: true
   #TieringPolicy - Tiering policy to be used during provisioning
   #                Requires FAST VP license.
@@ -106,8 +106,9 @@ allowedTopologies:
       - key: csi-unity.dellemc.com/<array_id>-nfs
         values:
           - "true"
-# mountOptions - Defines mount input values
+# mountOptions - Defines mount input values.
 # Default value: []
 # Optional: false
-# Examples: "hard" mount with NFS , "context" mount for block storage
+# Examples: "hard"    - option for mounting with NFS
+#           "context" - option for mounting with block storage
 mountOptions: ["<mountOption1>", "<mountOption2>", ..., "<mountOptionN>"]

--- a/samples/storageclass/unity-nfs.yaml
+++ b/samples/storageclass/unity-nfs.yaml
@@ -85,7 +85,7 @@ parameters:
   #   "2" for "Highest Available Tier"
   #   "3" for "Lowest Available Tier"
   tieringPolicy: <TIERING_POLICY>
-  # nasServer - Define NAS Server,the value from the storage array GUI nasServer column labeled "CLI ID" .
+  # nasServer - Defines the value from NAS Servers which should be picked from the column labeled "CLI ID"  in the storage array GUI.
   # Default value: None
   # Optional: false
   # Examples : nasserver_0

--- a/samples/storageclass/unity-nfs.yaml
+++ b/samples/storageclass/unity-nfs.yaml
@@ -53,7 +53,7 @@ parameters:
   # Default value: None
   # Examples: "APM000000001", "APM000000002"
   arrayId: <ARRAY_ID>
-  #storagePool - Define Storage pool CLI Id of the storage array.
+  #storagePool - Defines Storage pool, the value from the storage array GUI Pools column labeled "CLI ID".
   # Allowed values: String
   # Default value: None
   # Optional: false
@@ -68,18 +68,24 @@ parameters:
   thinProvisioned: true
   #isDataReductionEnabled - Defines Boolean to choose value of is DataReductionEnabled while creating a new volume
   # Allowed values: 
-  #    true      - to enable data reduction
-  #    false     - to disable data reduction
+  #    true      - to enable data reduction for all-flash storage pool.
+  #    false     - to disable data reduction for any storage pool.
   # Default value: false
   # Optional: true
   isDataReductionEnabled: true
-  #tieringPolicy - Define Tiering policy that is to be used for provisioning
+  #TieringPolicy - Tiering policy to be used during provisioning
+  #                Requires FAST VP license.
   # Allowed values: String
-  # Default value: None
   # Optional: true
   # Examples: "0"
+  # Default value: None
+  # Accepted values:
+  #   "0" for "Start High Then Auto-Tier"
+  #   "1" for "Auto-Tier"
+  #   "2" for "Highest Available Tier"
+  #   "3" for "Lowest Available Tier"
   tieringPolicy: <TIERING_POLICY>
-  # nasServer - Define NAS Server for the filesystem here
+  # nasServer - Define NAS Server,the value from the storage array GUI nasServer column labeled "CLI ID" .
   # Default value: None
   # Optional: false
   # Examples : nasserver_0
@@ -88,14 +94,20 @@ parameters:
   # Default value: None
   # Optional: false
   # Examples : 8192
-  hostIoSize: <HOST_IO_SIZE> 
+  hostIoSize: <HOST_IO_SIZE>
+# Restrict provisioning to specific topologies
+# Allowed values: map of key-value pairs
+# Optional: false
+# Default value: None
+# Examples: "apm0020280XXXX" , "apm0021340XXXX"
+# Here first three characters  should be in small letters.
 allowedTopologies:
   - matchLabelExpressions:
       - key: csi-unity.dellemc.com/<array_id>-nfs
         values:
           - "true"
-# mountOptions - Defines mount input vlaues
-# Default value: None
+# mountOptions - Defines mount input values
+# Default value: []
 # Optional: false
-# Examples: "/dev/sdc", "/dev/unity"      
+# Examples: "hard" mount with NFS , "context" mount for block storage
 mountOptions: ["<mountOption1>", "<mountOption2>", ..., "<mountOptionN>"]

--- a/samples/storageclass/unity-nfs.yaml
+++ b/samples/storageclass/unity-nfs.yaml
@@ -53,7 +53,7 @@ parameters:
   # Default value: None
   # Examples: "APM000000001", "APM000000002"
   arrayId: <ARRAY_ID>
-  #storagePool - Defines the value from Pools which should be picked from the column labeled "CLI ID"  in the storage array GUI.
+  #storagePool - Defines storage pool. The value should be picked from the column labeled "CLI ID" of Pools in the Unisphere GUI.
   # Allowed values: String
   # Default value: None
   # Optional: false
@@ -85,7 +85,7 @@ parameters:
   #   "2" for "Highest Available Tier"
   #   "3" for "Lowest Available Tier"
   tieringPolicy: <TIERING_POLICY>
-  # nasServer - Defines the value from NAS Servers which should be picked from the column labeled "CLI ID"  in the storage array GUI.
+  # nasServer - Defines storage NAS Servers. The value should be picked from the column labeled "CLI ID" of NAS Servers tab in the Unisphere GUI.
   # Default value: None
   # Optional: false
   # Examples : nasserver_0
@@ -109,6 +109,7 @@ allowedTopologies:
 # mountOptions - Defines mount input values.
 # Default value: []
 # Optional: false
-# Examples: "hard"    - option for mounting with NFS
-#           "context" - option for mounting with block storage
+# Examples:
+#   "hard"    - option for mounting with NFS
+#   "context" - option for mounting with block storage
 mountOptions: ["<mountOption1>", "<mountOption2>", ..., "<mountOptionN>"]


### PR DESCRIPTION
# Description
csi-unity sample storageclass documentation needs improvement

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/128 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
1. Tested with tiring policy setting to "0" , "1" etc.. and works as expected
2. Tested setting mount options hard and context and mount attached as hard and context respectively and works as expected
<img width="382" alt="2" src="https://user-images.githubusercontent.com/92289639/153539033-ee2808d5-9ab7-4956-92b3-5770e2dd10c8.PNG">

3.  Tested setiing matchLabelExpressions key starting with capital like APM00202802812 for both nfs and iscsi and it will not work. Hence mentioned **"Here first three characters  should be in small letters"** . Hence the format should be as bellow :

- matchLabelExpressions:
  - key: "csi-unity.dellemc.com/apm00202802812-nfs"
 
4. Explained the array requirement for Data Reduction enabled and also selection of storage pool and nas server via "CLI ID"


  