### PR TITLE
KRV-4177 : Bumping up CSI Unity XT version to 2.3.0

### DIFF
--- a/Dockerfile.podman
+++ b/Dockerfile.podman
@@ -34,6 +34,6 @@ LABEL vendor="Dell Inc." \
       name="csi-unity" \
       summary="CSI Driver for Dell EMC Unity" \
       description="CSI Driver for provisioning persistent storage from Dell EMC Unity" \
-      version="2.2.0" \
+      version="2.3.0" \
       license="Apache-2.0"
 COPY csi-unity/licenses /licenses

--- a/dell-csi-helm-installer/csi-install.sh
+++ b/dell-csi-helm-installer/csi-install.sh
@@ -15,7 +15,7 @@ PROG="${0}"
 NODE_VERIFY=1
 VERIFY=1
 MODE="install"
-DEFAULT_DRIVER_VERSION="2.2.0"
+DEFAULT_DRIVER_VERSION="2.3.0"
 WATCHLIST=""
 
 # export the name of the debug log, so child processes will see it

--- a/helm/csi-unity/Chart.yaml
+++ b/helm/csi-unity/Chart.yaml
@@ -1,6 +1,6 @@
 name: csi-unity
-version: 2.2.0
-appVersion: 2.2.0
+version: 2.3.0
+appVersion: 2.3.0
 kubeVersion: ">= 1.21.0 < 1.24.0"
 # If you are using a complex K8s version like "v1.21.3-mirantis-1", use this kubeVersion check instead
 # WARNING: this version of the check will allow the use of alpha and beta versions, which is NOT SUPPORTED

--- a/helm/csi-unity/values.yaml
+++ b/helm/csi-unity/values.yaml
@@ -3,8 +3,8 @@
 
 # version: version of this values file
 # Note: Do not change this value
-# Examples : "v2.2.0" , "nightly"
-version: "v2.2.0"
+# Examples : "v2.3.0" , "nightly"
+version: "v2.3.0"
 
 # LogLevel is used to set the logging level of the driver.
 # Allowed values: "error", "warn"/"warning", "info", "debug"

--- a/test/sanity/README.md
+++ b/test/sanity/README.md
@@ -1,7 +1,7 @@
 # Kubernetes Sanity Script Test
 
 This test runs the Kubernetes sanity test at https://github.com/kubernetes-csi/csi-test.
-The test last qualified was v2.2.0.
+The test last qualified was v2.3.0.
 
 To run the test, follow these steps:
 


### PR DESCRIPTION
# Description
Bumping up CSI Unity XT version to 2.3.0

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/243 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Installation:
![1](https://user-images.githubusercontent.com/92289639/161767635-31eb0155-07b9-456e-ba30-30ec2f1890af.JPG)
