### PR TITLE
Update verify script to validate min and max versions supported for Openshift

### DIFF
--- a/dell-csi-helm-installer/verify-csi-unity.sh
+++ b/dell-csi-helm-installer/verify-csi-unity.sh
@@ -11,7 +11,7 @@
 # verify-csi-unity method
 function verify-csi-unity() {
   verify_k8s_versions "1.21" "1.23"
-  verify_openshift_versions "4.8" "4.9"
+  verify_openshift_versions "4.9" "4.10"
   verify_namespace "${NS}"
   verify_required_secrets "${RELEASE}-creds"
   verify_optional_secrets "${RELEASE}-certs"

--- a/dell-csi-helm-installer/verify.sh
+++ b/dell-csi-helm-installer/verify.sh
@@ -219,12 +219,12 @@ function verify_openshift_versions() {
 
   local MIN=${1}
   local MAX=${2}
-  local V="${oMajorVersion}.${oMinorVersion}"
+  local V=$(OpenShiftVersion)
   # check minimum
   log arrow
   log smart_step "Verifying minimum OpenShift version" "small"
   error=0
-  if [[ ${V} < ${MIN} ]]; then
+  if (( ${V%%.*} < ${MIN%%.*} || ( ${V%%.*} == ${MIN%%.*} && ${V##*.} < ${MIN##*.} ) )) ; then
     error=1
     found_error "OpenShift version ${V} is too old. Minimum required version is: ${MIN}"
   fi
@@ -234,7 +234,7 @@ function verify_openshift_versions() {
   log arrow
   log smart_step "Verifying maximum OpenShift version" "small"
   error=0
-  if [[ ${V} > ${MAX} ]]; then
+  if (( ${V%%.*} > ${MAX%%.*} || ( ${V%%.*} == ${MAX%%.*} && ${V##*.} > ${MAX##*.} ) )) ; then
     error=1
     found_warning "OpenShift version ${V} is newer than the version that has been tested. Latest tested version is: ${MAX}"
   fi
@@ -569,10 +569,6 @@ MASTER_NODES=$(run_command kubectl get nodes -o wide | awk ' /master/{ print $6;
 # Get the kubernetes major and minor version numbers.
 kMajorVersion=$(run_command kubectl version | grep 'Server Version' | sed -e 's/^.*Major:"//' -e 's/[^0-9].*//g')
 kMinorVersion=$(run_command kubectl version | grep 'Server Version' | sed -e 's/^.*Minor:"//' -e 's/[^0-9].*//g')
-# Get the openshift major and minor version numbers.
-oVersion=$(run_command kubectl get clusterversions -o jsonpath="{.items[*].status.desired.version}")
-oMajorVersion=$(echo "${oVersion}" | awk -F '.' '{print $1}')
-oMinorVersion=$(echo "${oVersion}" | awk -F '.' '{print $2}')
 
 # get the list of valid CSI Drivers, this will be the list of directories in drivers/ that contain helm charts
 get_drivers "${SCRIPTDIR}/../helm"

--- a/dell-csi-helm-installer/verify.sh
+++ b/dell-csi-helm-installer/verify.sh
@@ -219,7 +219,7 @@ function verify_openshift_versions() {
 
   local MIN=${1}
   local MAX=${2}
-  local V=$(OpenShiftVersion)
+  local V="${oMajorVersion}.${oMinorVersion}"
   # check minimum
   log arrow
   log smart_step "Verifying minimum OpenShift version" "small"
@@ -569,6 +569,10 @@ MASTER_NODES=$(run_command kubectl get nodes -o wide | awk ' /master/{ print $6;
 # Get the kubernetes major and minor version numbers.
 kMajorVersion=$(run_command kubectl version | grep 'Server Version' | sed -e 's/^.*Major:"//' -e 's/[^0-9].*//g')
 kMinorVersion=$(run_command kubectl version | grep 'Server Version' | sed -e 's/^.*Minor:"//' -e 's/[^0-9].*//g')
+# Get the openshift major and minor version numbers.
+oVersion=$(run_command kubectl get clusterversions -o jsonpath="{.items[*].status.desired.version}")
+oMajorVersion=$(echo "${oVersion}" | awk -F '.' '{print $1}')
+oMinorVersion=$(echo "${oVersion}" | awk -F '.' '{print $2}')
 
 # get the list of valid CSI Drivers, this will be the list of directories in drivers/ that contain helm charts
 get_drivers "${SCRIPTDIR}/../helm"


### PR DESCRIPTION
# Description
As part of OCP 4.10 support for csi-unity driver , fixed verify script which validates MIN and MAX versions of Openshift supported by the driver

# GitHub Issues

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/305 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Tested helm installation checks for positive and negative scenarios in OCP 4.10 env. Please find below screenshots for reference:

![Min_version_check_410](https://user-images.githubusercontent.com/82365588/168547964-fe2f9e0e-a68c-473a-b19b-bb20864a0460.JPG)

![max_version_check](https://user-images.githubusercontent.com/82365588/168548025-234b1f8e-221b-4846-8335-5f1dfe17ec63.JPG)

