### PR TITLE
Add label to driver node pod for Resiliency protection

### DIFF
--- a/helm/csi-unity/templates/node.yaml
+++ b/helm/csi-unity/templates/node.yaml
@@ -72,6 +72,9 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-node
+{{- if .Values.podmon.enabled }}
+        driver.dellemc.com: dell-storage
+{{- end }}
     spec:
       serviceAccountName: {{ .Release.Name }}-node
       {{- if .Values.node.nodeSelector }}
@@ -129,7 +132,6 @@ spec:
               mountPropagation: "Bidirectional"
             - name: dev
               mountPath: /dev
-              mountPropagation: "Bidirectional"
             - name: usr-bin
               mountPath: /usr-bin
             - name: var-run

--- a/helm/csi-unity/values.yaml
+++ b/helm/csi-unity/values.yaml
@@ -149,7 +149,7 @@ podmon:
   # allowed values - string
   # default value : None
   # Example : "podman:latest", "pod:latest"
-  image: dellemc/podmon:v1.1.0
+  image: dellemc/podmon:v1.2.0
 #  controller:
 #    args:
 #      - "--csisock=unix:/var/run/csi/csi.sock"
@@ -158,6 +158,7 @@ podmon:
 #      - "--mode=controller"
 #      - "--skipArrayConnectionValidation=false"
 #      - "--driver-config-params=/unity-config/driver-config-params.yaml"
+#      - "--driverPodLabelValue=dell-storage"
 #  node:
 #    args:
 #      - "--csisock=unix:/var/lib/kubelet/plugins/unity.emc.dell.com/csi_sock"
@@ -166,6 +167,7 @@ podmon:
 #      - "--mode=node"
 #      - "--leaderelection=false"
 #      - "--driver-config-params=/unity-config/driver-config-params.yaml"
+#      - "--driverPodLabelValue=dell-storage"
 
 ### The below parameters have been discontinued for configuration from secret.yaml and will have to be configured only in values.yaml
 


### PR DESCRIPTION
# Description

Protect CSI driver node pods to avoid storage workload scheduling. With this label CSM for Resiliency will protect the CSI Driver node pods, and for some reason CSI Driver node pods are not in ready state, CSM for Resiliency will taint that node. With taint in the node kubelet will not schedule jobs in that node.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| #https://github.com/dell/csm/issues/145 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
