### PR TITLE
Update node selector value to control plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CSI Driver for Dell Unity XT
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/dell/csi-unity?style=flat-square)](https://goreportcard.com/report/github.com/dell/csi-unity)
-[![License](https://img.shields.io/github/license/dell/csi-unity?style=flat-square&color=blue&label=License)](https://github.com/dell/csi-unity/blob/master/LICENSE)
+[![License](https://img.shields.io/github/license/dell/csi-unity?style=flat-square&color=blue&label=License)](https://github.com/dell/csi-unity/blob/main/LICENSE)
 [![Docker](https://img.shields.io/docker/pulls/dellemc/csi-unity.svg?logo=docker&style=flat-square&label=Pulls)](https://hub.docker.com/r/dellemc/csi-unity)
 [![Last Release](https://img.shields.io/github/v/release/dell/csi-unity?label=Latest&style=flat-square&logo=go)](https://github.com/dell/csi-unity/releases)
 

--- a/helm/csi-unity/values.yaml
+++ b/helm/csi-unity/values.yaml
@@ -72,14 +72,14 @@ controller:
   # Allowed values: map of key-value pairs
   # Default value: None
   # Examples:
-  #   node-role.kubernetes.io/master: ""
+  #   node-role.kubernetes.io/control-plane: ""
   nodeSelector:
 
   # tolerations: Define tolerations for the controllers, if required.
   # Leave as blank to install controller on worker nodes
   # Default value: None
   tolerations:
-  #  - key: "node-role.kubernetes.io/master"
+  #  - key: "node-role.kubernetes.io/control-plane"
   #    operator: "Exists"
   #    effect: "NoSchedule"
 
@@ -120,9 +120,9 @@ node:
   # Allowed values: map of key-value pairs
   # Default value: None
   # Examples:
-  #   node-role.kubernetes.io/master: ""
+  #   node-role.kubernetes.io/control-plane: ""
   nodeSelector:
-  #   node-role.kubernetes.io/master: ""
+  #   node-role.kubernetes.io/control-plane: ""
 
   # tolerations: Define tolerations for the node daemonset, if required.
   # Default value: None


### PR DESCRIPTION
# Description
Update node selector value from master to control plane

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/319|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Checked get nodes on 1.24, 1.23 and 1.22 and it supports control plane on all the versions
