### PR TITLE
CSI offline bundle installation fix for Unity XT

### DIFF
--- a/dell-csi-helm-installer/csi-offline-bundle.sh
+++ b/dell-csi-helm-installer/csi-offline-bundle.sh
@@ -163,6 +163,10 @@ fixup_files() {
       echo "   changing: $line -> ${NEWNAME}"
       find "${ROOTDIR}" -type f -not -path "${SCRIPTDIR}/*" -exec sed -i "s|$line|$NEWNAME|g" {} \;
   done < "${IMAGEMANIFEST}"
+
+  # Replacing values file with local registry
+  sed -i "s|driverRepository:.*|driverRepository: ${REGISTRY}|" ${VALUESFILE}
+  sed -i 's/\/$//' ${VALUESFILE}
 }
 
 # compress the whole bundle

--- a/dell-csi-helm-installer/csi-offline-bundle.sh
+++ b/dell-csi-helm-installer/csi-offline-bundle.sh
@@ -85,6 +85,11 @@ build_image_manifest() {
     fi
   done
 
+  # Forming this only for drivers supporting standalone helm charts
+  if [ ! -z ${DRIVERREPO} ]; then 
+   echo "${DRIVERREPO}/${DRIVERNAME}\:${DRIVERVERSIONVALUESYAML}"
+   echo "${DRIVERREPO}/${DRIVERNAME}:${DRIVERVERSIONVALUESYAML}" >> "${IMAGEMANIFEST}.tmp"
+  fi
   # sort and uniqify the list
   cat "${IMAGEMANIFEST}.tmp" | sort | uniq > "${IMAGEMANIFEST}"
   rm "${IMAGEMANIFEST}.tmp"
@@ -222,12 +227,15 @@ set_mode
 if [ "${MODE}" == "helm" ]; then
   INSTALLERDIR="${REPODIR}/dell-csi-helm-installer"
   CHARTFILE=$(find "${HELMDIR}" -maxdepth 2 -type f -name Chart.yaml)
+  VALUESFILE=$(find "${HELMDIR}" -maxdepth 2 -type f -name values.yaml)
 
   # some output files
   DRIVERNAME=$(grep -oh "^name:\s.*" "${CHARTFILE}" | awk '{print $2}')
   DRIVERNAME=${DRIVERNAME:-"dell-csi-driver"}
-  DRIVERVERSION=$(grep -oh "^version:\s.*" "${CHARTFILE}" | awk '{print $2}')
+  DRIVERVERSION=$(grep -oh "^version:\s.*" "${CHARTFILE}" | awk '{print $2}' | sed -e 's/^"//' -e 's/"$//')
   DRIVERVERSION=${DRIVERVERSION:-unknown}
+  DRIVERVERSIONVALUESYAML=$(grep -oh "^version:\s.*" "${VALUESFILE}" | awk '{print $2}' | sed -e 's/^"//' -e 's/"$//')
+  DRIVERREPO=$(grep -oh "driverRepository:\s.*" "${VALUESFILE}" | awk '{print $2}')
   DISTBASE="${REPODIR}"
   DRIVERDIR="${DRIVERNAME}-bundle-${DRIVERVERSION}"
   DISTDIR="${DISTBASE}/${DRIVERDIR}"


### PR DESCRIPTION
# Description
Fix for offline bundle installation for Unity XT

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/324|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Able to deploy CSI Unity driver using offline bundle
