### PR TITLE
Support for fsgrouppolicy 

### DIFF
--- a/helm/csi-unity/templates/csidriver.yaml
+++ b/helm/csi-unity/templates/csidriver.yaml
@@ -8,3 +8,4 @@ spec:
   volumeLifecycleModes:
     - Persistent
     - Ephemeral
+  fsGroupPolicy: {{ .Values.fsGroupPolicy }}

--- a/helm/csi-unity/values.yaml
+++ b/helm/csi-unity/values.yaml
@@ -30,6 +30,16 @@ imagePullPolicy: Always
 # Default value: None
 kubeletConfigDir: /var/lib/kubelet
 
+# fsGroupPolicy: Defines if the underlying volume supports changing ownership and permission of the volume before being mounted.
+# Allowed values:
+#   ReadWriteOnceWithFSType: supports volume ownership and permissions change only if the fsType is defined
+#   and the volume's accessModes contains ReadWriteOnce.
+#   File: kubernetes may use fsGroup to change permissions and ownership of the volume 
+#   to match user requested fsGroup in the pod's security policy regardless of fstype or access mode.
+#   None: volumes will be mounted with no modifications.
+# Default value: ReadWriteOnceWithFSType
+fsGroupPolicy: ReadWriteOnceWithFSType
+
 #To set nodeSelectors and tolerations for controller.
 # controller: configure controller pod specific parameters
 controller:


### PR DESCRIPTION
# Description
Support for fsGroupPolicy.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/361|

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Manual testing to verify fsGroupPolicy support works. 
![image](https://user-images.githubusercontent.com/92028646/177488699-99728f3a-970c-431a-9481-46570ddee75c.png)
![image](https://user-images.githubusercontent.com/92028646/177488760-c2e27a70-e046-4d7a-b316-e284a2208409.png)
![image](https://user-images.githubusercontent.com/92028646/177488839-dcfbe003-a9ff-46be-ac9c-c65f1ae3d2fa.png)



- [x] k8s e2e test run for fsGroupPolicy. One scenario was failing which was verified by manual test. 
[e2e logs.txt](https://github.com/dell/csi-unity/files/9052345/e2e.logs.txt)
pod spec
![image](https://user-images.githubusercontent.com/92028646/177492567-61f5dfa1-8ba0-4883-ae44-76203cd89430.png)
Group id of mounted volume
![image](https://user-images.githubusercontent.com/92028646/177492591-1922a591-2ffe-4dca-a5b4-849f23692417.png)
Change group id of data0/volume1/subdir/file -> 2000
data0/volume1/subdir -> 3000
![image](https://user-images.githubusercontent.com/92028646/177492637-8eb42892-6857-4e74-8664-8214495576e5.png)
Delete pod and create new pod with same fsgroup, new pod with same fsgroup skips ownership changes to the volume contents
![image](https://user-images.githubusercontent.com/92028646/177492685-5a4a2239-a283-4ec9-86f1-07c5da56abf5.png)


