### PR TITLE
Sidecar Updates

### DIFF
--- a/dell-csi-helm-installer/verify-csi-unity.sh
+++ b/dell-csi-helm-installer/verify-csi-unity.sh
@@ -10,7 +10,7 @@
 
 # verify-csi-unity method
 function verify-csi-unity() {
-  verify_k8s_versions "1.24" "1.27"
+  verify_k8s_versions "1.22" "1.27"
   verify_openshift_versions "4.11" "4.12"
   verify_namespace "${NS}"
   verify_required_secrets "${RELEASE}-creds"

--- a/dell-csi-helm-installer/verify-csi-unity.sh
+++ b/dell-csi-helm-installer/verify-csi-unity.sh
@@ -10,7 +10,7 @@
 
 # verify-csi-unity method
 function verify-csi-unity() {
-  verify_k8s_versions "1.22" "1.27"
+  verify_k8s_versions "1.24" "1.27"
   verify_openshift_versions "4.11" "4.12"
   verify_namespace "${NS}"
   verify_required_secrets "${RELEASE}-creds"

--- a/helm/csi-unity/Chart.yaml
+++ b/helm/csi-unity/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: 2.7.0
 kubeVersion: ">= 1.25.0 < 1.28.0"
 # If you are using a complex K8s version like "v1.24.3-mirantis-1", use this kubeVersion check instead
 # WARNING: this version of the check will allow the use of alpha and beta versions, which is NOT SUPPORTED
-# kubeVersion: ">= 1.22.0-0 < 1.28.0-0"
+# kubeVersion: ">= 1.24.0-0 < 1.28.0-0"
 description: |
   Unity XT CSI (Container Storage Interface) driver Kubernetes
   integration. This chart includes everything required to provision via CSI as

--- a/helm/csi-unity/Chart.yaml
+++ b/helm/csi-unity/Chart.yaml
@@ -1,7 +1,7 @@
 name: csi-unity
 version: 2.7.0
 appVersion: 2.7.0
-kubeVersion: ">= 1.25.0 < 1.28.0"
+kubeVersion: ">= 1.24.0 < 1.28.0"
 # If you are using a complex K8s version like "v1.24.3-mirantis-1", use this kubeVersion check instead
 # WARNING: this version of the check will allow the use of alpha and beta versions, which is NOT SUPPORTED
 # kubeVersion: ">= 1.24.0-0 < 1.28.0-0"

--- a/helm/csi-unity/templates/_helpers.tpl
+++ b/helm/csi-unity/templates/_helpers.tpl
@@ -3,7 +3,7 @@ Return the appropriate sidecar images based on k8s version
 */}}
 {{- define "csi-unity.attacherImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "24") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
       {{- print "registry.k8s.io/sig-storage/csi-attacher:v4.3.0" -}}
     {{- end -}}
   {{- end -}}
@@ -11,7 +11,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-unity.provisionerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "24") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
       {{- print "registry.k8s.io/sig-storage/csi-provisioner:v3.5.0" -}}
     {{- end -}}
   {{- end -}}
@@ -19,7 +19,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-unity.snapshotterImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "24") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
       {{- print "registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2" -}}
     {{- end -}}
   {{- end -}}
@@ -27,7 +27,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-unity.resizerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "24") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
       {{- print "registry.k8s.io/sig-storage/csi-resizer:v1.8.0" -}}
     {{- end -}}
   {{- end -}}
@@ -35,7 +35,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-unity.registrarImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "24") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
       {{- print "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0" -}}
     {{- end -}}
   {{- end -}}
@@ -43,7 +43,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-unity.healthmonitorImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "24") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
       {{- print "registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.9.0" -}}
     {{- end -}}
   {{- end -}}

--- a/helm/csi-unity/templates/_helpers.tpl
+++ b/helm/csi-unity/templates/_helpers.tpl
@@ -4,7 +4,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-unity.attacherImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "registry.k8s.io/sig-storage/csi-attacher:v4.2.0" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-attacher:v4.3.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -12,7 +12,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-unity.provisionerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "registry.k8s.io/sig-storage/csi-provisioner:v3.4.0" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-provisioner:v3.5.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -20,7 +20,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-unity.snapshotterImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "registry.k8s.io/sig-storage/csi-snapshotter:v6.2.1" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -28,7 +28,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-unity.resizerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "registry.k8s.io/sig-storage/csi-resizer:v1.7.0" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-resizer:v1.8.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -36,7 +36,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-unity.registrarImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.3" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -44,7 +44,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-unity.healthmonitorImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.8.0" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.9.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/helm/csi-unity/templates/_helpers.tpl
+++ b/helm/csi-unity/templates/_helpers.tpl
@@ -3,7 +3,7 @@ Return the appropriate sidecar images based on k8s version
 */}}
 {{- define "csi-unity.attacherImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "24") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
       {{- print "registry.k8s.io/sig-storage/csi-attacher:v4.3.0" -}}
     {{- end -}}
   {{- end -}}
@@ -11,7 +11,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-unity.provisionerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "24") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
       {{- print "registry.k8s.io/sig-storage/csi-provisioner:v3.5.0" -}}
     {{- end -}}
   {{- end -}}
@@ -19,7 +19,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-unity.snapshotterImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "24") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
       {{- print "registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2" -}}
     {{- end -}}
   {{- end -}}
@@ -27,7 +27,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-unity.resizerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "24") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
       {{- print "registry.k8s.io/sig-storage/csi-resizer:v1.8.0" -}}
     {{- end -}}
   {{- end -}}
@@ -35,7 +35,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-unity.registrarImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "24") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
       {{- print "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0" -}}
     {{- end -}}
   {{- end -}}
@@ -43,7 +43,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-unity.healthmonitorImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "22") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "24") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
       {{- print "registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.9.0" -}}
     {{- end -}}
   {{- end -}}

--- a/helm/csi-unity/values.yaml
+++ b/helm/csi-unity/values.yaml
@@ -3,8 +3,8 @@
 
 # version: version of this values file
 # Note: Do not change this value
-# Examples : "v2.6.0" , "nightly"
-version: "v2.6.0"
+# Examples : "v2.7.0" , "nightly"
+version: "v2.7.0"
 
 # LogLevel is used to set the logging level of the driver.
 # Allowed values: "error", "warn"/"warning", "info", "debug"


### PR DESCRIPTION
# Description
Update the sidecar versions to the following:
external-attacher v4.3.0
external-provisioner v3.5.0
external-resizer v1.8.0
external-health-monitor v0.9.0
external-snapshotter v6.2.2
node-driver-registrar v2.8.0

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/743 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Sanity tests:
![image](https://github.com/dell/csi-unity/assets/92028646/162ec49f-2a24-43df-99d8-28ed0bfe7fb2)
![image](https://github.com/dell/csi-unity/assets/92028646/773cbd88-40a1-4431-a592-c2e825e1a11d)

Cert-csi:
![image](https://github.com/dell/csi-unity/assets/92028646/8bc7ea24-5c37-4cbd-a697-727aa3b18ff9)


