### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/core/semver/semver.go
+++ b/core/semver/semver.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -72,7 +71,7 @@ func main() {
 		format = "ver"
 	} else {
 		if fileExists(format) {
-			buf, err := ioutil.ReadFile(filepath.Clean(format))
+			buf, err := os.ReadFile(filepath.Clean(format))
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "error: read tpl failed: %v\n", err)
 				os.Exit(1)

--- a/service/mount.go
+++ b/service/mount.go
@@ -17,7 +17,6 @@ package service
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -666,7 +665,7 @@ func getDevMounts(ctx context.Context, sysDevice *Device) ([]gofsutil.Info, erro
 			//Find the multipath device mapper from the device obtained
 			mpDevName := strings.TrimPrefix(sysDevice.RealDev, "/dev/")
 			filename := fmt.Sprintf("/sys/devices/virtual/block/%s/dm/name", mpDevName)
-			if name, err := ioutil.ReadFile(filepath.Clean(filename)); err != nil {
+			if name, err := os.ReadFile(filepath.Clean(filename)); err != nil {
 				log.Warn("Could not read mp dev name file ", filename, err)
 			} else {
 				mpathDev := strings.TrimSpace(string(name))
@@ -694,7 +693,7 @@ func getMpathDevFromWwn(ctx context.Context, volumeWwn string) (string, error) {
 
 	mpDevName := strings.TrimPrefix(sysDevice.RealDev, "/dev/")
 	filename := fmt.Sprintf("/sys/devices/virtual/block/%s/dm/name", mpDevName)
-	name, err := ioutil.ReadFile(filepath.Clean(filename))
+	name, err := os.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		log.Error("Could not read mp dev name file ", filename, err)
 		return "", err

--- a/service/node.go
+++ b/service/node.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -568,7 +567,7 @@ func (s *service) NodeUnpublishVolume(
 	file := s.opts.EnvEphemeralStagingTargetPath + req.VolumeId + "/id"
 	if _, err := os.Stat(file); err == nil {
 		isEphemeralVolume = true
-		dat, err := ioutil.ReadFile(filepath.Clean(file))
+		dat, err := os.ReadFile(filepath.Clean(file))
 		if err != nil {
 			return nil, errors.New("Unable to get volume id for ephemeral volume")
 		}
@@ -891,7 +890,7 @@ func (s *service) NodeGetVolumeStats(
 	}
 
 	// check if volume path is accessible
-	_, err = ioutil.ReadDir(volumePath)
+	_, err = os.ReadDir(volumePath)
 	if err != nil {
 		resp := &csi.NodeGetVolumeStatsResponse{
 			VolumeCondition: &csi.VolumeCondition{
@@ -1446,7 +1445,7 @@ func (s *service) disconnectVolume(ctx context.Context, volumeWWN, protocol stri
 		time.Sleep(disconnectVolumeRetryTime)
 
 		// Check that the /sys/block/DeviceName actually exists
-		if _, err := ioutil.ReadDir(sysBlock + deviceName); err != nil {
+		if _, err := os.ReadDir(sysBlock + deviceName); err != nil {
 			// If not, make sure the symlink is removed
 			var err2 error
 			log.Debugf("Removing device %s", symlinkPath)

--- a/service/service.go
+++ b/service/service.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -477,7 +476,7 @@ func (s *service) syncDriverSecret(ctx context.Context) error {
 		s.arrays.Delete(key)
 		return true
 	})
-	secretBytes, err := ioutil.ReadFile(filepath.Clean(DriverSecret))
+	secretBytes, err := os.ReadFile(filepath.Clean(DriverSecret))
 	if err != nil {
 		return fmt.Errorf("File ('%s') error: %v", DriverSecret, err)
 	}

--- a/service/utils/emcutils.go
+++ b/service/utils/emcutils.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -99,7 +98,7 @@ func GetFCInitiators(ctx context.Context) ([]string, error) {
 	portWWNs := make([]string, 0)
 	// Read the directory entries for fc_remote_ports
 	fcHostsDir := "/sys/class/fc_host"
-	hostEntries, err := ioutil.ReadDir(fcHostsDir)
+	hostEntries, err := os.ReadDir(fcHostsDir)
 	if err != nil {
 		log.Warnf("Cannot read directory: %s : %v", fcHostsDir, err)
 		return portWWNs, err
@@ -111,7 +110,7 @@ func GetFCInitiators(ctx context.Context) ([]string, error) {
 			continue
 		}
 		portPath := fcHostsDir + "/" + host.Name() + "/" + "port_name"
-		portName, err := ioutil.ReadFile(filepath.Clean(portPath))
+		portName, err := os.ReadFile(filepath.Clean(portPath))
 		if err != nil {
 			log.Warnf("Error reading file: %s Error: %v", portPath, err)
 			continue
@@ -119,7 +118,7 @@ func GetFCInitiators(ctx context.Context) ([]string, error) {
 		portNameStr := strings.TrimSpace(string(portName))
 
 		nodePath := fcHostsDir + "/" + host.Name() + "/" + "node_name"
-		nodeName, err := ioutil.ReadFile(filepath.Clean(nodePath))
+		nodeName, err := os.ReadFile(filepath.Clean(nodePath))
 		if err != nil {
 			log.Warnf("Error reading file: %s Error: %v", nodePath, err)
 			continue

--- a/test/integration-test/integration_main_test.go
+++ b/test/integration-test/integration_main_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"testing"
@@ -47,7 +46,7 @@ func TestMain(m *testing.M) {
 	var stop func()
 	os.Setenv("X_CSI_MODE", "")
 
-	file, err := ioutil.ReadFile(os.Getenv("DRIVER_CONFIG"))
+	file, err := os.ReadFile(os.Getenv("DRIVER_CONFIG"))
 	if err != nil {
 		panic("Driver Config missing")
 	}

--- a/test/unit-test/unit_main_test.go
+++ b/test/unit-test/unit_main_test.go
@@ -17,7 +17,6 @@ package unit_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"testing"
@@ -48,7 +47,7 @@ type StorageArrayConfig struct {
 func TestMain(m *testing.M) {
 	os.Setenv("X_CSI_MODE", "")
 
-	file, err := ioutil.ReadFile(os.Getenv("DRIVER_SECRET"))
+	file, err := os.ReadFile(os.Getenv("DRIVER_SECRET"))
 	if err != nil {
 		panic("Driver Config missing")
 	}


### PR DESCRIPTION
# Description
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
