### PR TITLE
add k8s 1.28 support

### DIFF
--- a/dell-csi-helm-installer/verify-csi-unity.sh
+++ b/dell-csi-helm-installer/verify-csi-unity.sh
@@ -10,7 +10,7 @@
 
 # verify-csi-unity method
 function verify-csi-unity() {
-  verify_k8s_versions "1.24" "1.27"
+  verify_k8s_versions "1.24" "1.28"
   verify_openshift_versions "4.12" "4.13"
   verify_namespace "${NS}"
   verify_required_secrets "${RELEASE}-creds"


### PR DESCRIPTION
# Description
Add k8s 1.28 support in CSI Unity XT Driver

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/947 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Sanity test -> Driver installs successfully on 1.28 k8s cluster 
![image](https://github.com/dell/csi-unity/assets/92028646/23fd4ccb-2143-4d3c-a270-7f129c6a6349)
Test pods and PVC
![image](https://github.com/dell/csi-unity/assets/92028646/056a7b27-faa8-4c82-983a-5583bf26966c)

