### PR TITLE
Update base ubi image to lalest ubi micro 9.3-6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,15 +26,21 @@ integration-test:
 unit-test:
 	( cd test/unit-test; sh run.sh )
 
+.PHONY: download-csm-common
+download-csm-common:
+	curl -O -L https://raw.githubusercontent.com/dell/csm/main/config/csm-common.mk
+
 #
 # Docker-related tasks
 #
 # Generates the docker container (but does not push)
-podman-build: go-build
-	sh build.sh
+podman-build: download-csm-common go-build
+    $(eval include csm-common.mk)
+	sh build.sh --baseubi $(DEFAULT_BASEIMAGE)
 
-podman-push: go-build
-	sh build.sh -p
+podman-push: download-csm-common go-build
+    $(eval include csm-common.mk)
+	sh build.sh --baseubi $(DEFAULT_BASEIMAGE) --push
 
 #
 # Docker-related tasks

--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,11 @@ download-csm-common:
 #
 # Generates the docker container (but does not push)
 podman-build: download-csm-common go-build
-    $(eval include csm-common.mk)
+	$(eval include csm-common.mk)
 	sh build.sh --baseubi $(DEFAULT_BASEIMAGE)
 
 podman-push: download-csm-common go-build
-    $(eval include csm-common.mk)
+	$(eval include csm-common.mk)
 	sh build.sh --baseubi $(DEFAULT_BASEIMAGE) --push
 
 #

--- a/build.sh
+++ b/build.sh
@@ -28,9 +28,10 @@ function git_version {
    echo Target Version=$VERSION
 }
 
+
 function build_image {
-   # Tag corresponding to digest sha256:630cf7bdef807f048cadfe7180d6c27eb3aaa99323ffc3628811da230ed3322a for ubi9 micro is 9.2-13
-   bash build_ubi_micro.sh registry.access.redhat.com/ubi9/ubi-micro@sha256:630cf7bdef807f048cadfe7180d6c27eb3aaa99323ffc3628811da230ed3322a
+   # Tag corresponding to digest sha256:d14ac3ae12148f838511d08261e1569fb2a54da4c54a817aea7f16c1c9078f0b for ubi9 micro is 9.2-15
+   bash build_ubi_micro.sh registry.redhat.io/ubi9/ubi-micro@sha256:d14ac3ae12148f838511d08261e1569fb2a54da4c54a817aea7f16c1c9078f0b
    echo $BUILDCMD build -t ${IMAGE_NAME}:${IMAGE_TAG} .
    (cd .. && $BUILDCMD build -t ${IMAGE_NAME}:${IMAGE_TAG} --build-arg GOPROXY=$GOPROXY -f csi-unity/Dockerfile.podman . --format=docker)
    echo $BUILDCMD tag ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_REPO}/${IMAGE_REPO_NAMESPACE}/${IMAGE_NAME}:${IMAGE_TAG}

--- a/build.sh
+++ b/build.sh
@@ -30,8 +30,8 @@ function git_version {
 
 
 function build_image {
-   # Tag corresponding to digest sha256:d14ac3ae12148f838511d08261e1569fb2a54da4c54a817aea7f16c1c9078f0b for ubi9 micro is 9.2-15
-   bash build_ubi_micro.sh registry.redhat.io/ubi9/ubi-micro@sha256:d14ac3ae12148f838511d08261e1569fb2a54da4c54a817aea7f16c1c9078f0b
+   # Tag corresponding to digest sha256:b7d8fd2840e92e8adc68414e13d859763ef33c3d4c4e27f910e939c00d642c29 for ubi9 micro is 9.3-6
+   bash build_ubi_micro.sh registry.access.redhat.com/ubi9/ubi-micro@sha256:b7d8fd2840e92e8adc68414e13d859763ef33c3d4c4e27f910e939c00d642c29
    echo $BUILDCMD build -t ${IMAGE_NAME}:${IMAGE_TAG} .
    (cd .. && $BUILDCMD build -t ${IMAGE_NAME}:${IMAGE_TAG} --build-arg GOPROXY=$GOPROXY -f csi-unity/Dockerfile.podman . --format=docker)
    echo $BUILDCMD tag ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_REPO}/${IMAGE_REPO_NAMESPACE}/${IMAGE_NAME}:${IMAGE_TAG}

--- a/build.sh
+++ b/build.sh
@@ -30,8 +30,8 @@ function git_version {
 
 
 function build_image {
-   # Tag corresponding to digest sha256:b7d8fd2840e92e8adc68414e13d859763ef33c3d4c4e27f910e939c00d642c29 for ubi9 micro is 9.3-6
-   bash build_ubi_micro.sh registry.access.redhat.com/ubi9/ubi-micro@sha256:b7d8fd2840e92e8adc68414e13d859763ef33c3d4c4e27f910e939c00d642c29
+   echo ${BASE_UBI_IMAGE}
+   bash build_ubi_micro.sh ${BASE_UBI_IMAGE}
    echo $BUILDCMD build -t ${IMAGE_NAME}:${IMAGE_TAG} .
    (cd .. && $BUILDCMD build -t ${IMAGE_NAME}:${IMAGE_TAG} --build-arg GOPROXY=$GOPROXY -f csi-unity/Dockerfile.podman . --format=docker)
    echo $BUILDCMD tag ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_REPO}/${IMAGE_REPO_NAMESPACE}/${IMAGE_NAME}:${IMAGE_TAG}
@@ -53,13 +53,17 @@ IMAGE_REPO_NAMESPACE=csi-unity
 IMAGE_TAG=${VERSION}
 
 # Read options
-while getopts 'ph' flag; do
-  case "${flag}" in
-    p) PUSH_IMAGE='true' ;;
-    h) git_version
-       exit 0 ;;
-    *) git_version
-       exit 0 ;;
+for param in $*; do
+  case $param in
+  "--baseubi")
+    shift
+    BASE_UBI_IMAGE=$1
+    shift
+    ;;
+  "--push")
+    shift
+    PUSH_IMAGE='true'
+    ;;
   esac
 done
 


### PR DESCRIPTION
# Description
Update base ubi image to lalest ubi micro 9.3-6. Update scripts to use common CSM ubi base image location.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| #https://github.com/dell/csm/issues/1031 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Run cert-csi suit for unity

[2023-11-07 13:55:04]  INFO Avg time of a run:	 73.61s
[2023-11-07 13:55:04]  INFO Avg time of a del:	 18.09s
[2023-11-07 13:55:04]  INFO Avg time of all:	 95.35s
[2023-11-07 13:55:04]  INFO During this run 100.0% of suites succeeded
CMD RETURNCODE IS: 0
ALL CERT-CSI RETURNCODEs: 0,0,0
All test(s) passed

