### PR TITLE
Fix capacity value after resize to lower capacity

### DIFF
--- a/service/controller.go
+++ b/service/controller.go
@@ -833,10 +833,7 @@ func (s *service) ControllerExpandVolume(ctx context.Context, req *csi.Controlle
 
 		// Idempotency check
 		if filesystem.FileContent.SizeTotal >= uint64(capacity) {
-			log.Infof("New Filesystem size (%d) is same as existing Filesystem size. Ignoring expand volume operation.", filesystem.FileContent.SizeTotal)
-			expandVolumeResp := &csi.ControllerExpandVolumeResponse{
-				CapacityBytes: 0,
-			}
+			log.Infof("New Filesystem size (%d) is lower or same as existing Filesystem size. Ignoring expand volume operation.", filesystem.FileContent.SizeTotal)
 			expandVolumeResp.NodeExpansionRequired = false
 			return expandVolumeResp, nil
 		}
@@ -869,9 +866,6 @@ func (s *service) ControllerExpandVolume(ctx context.Context, req *csi.Controlle
 
 	if volume.VolumeContent.SizeTotal >= uint64(capacity) {
 		log.Infof("New Volume size (%d) is same as existing Volume size. Ignoring expand volume operation.", volume.VolumeContent.SizeTotal)
-		/* 		expandVolumeResp := &csi.ControllerExpandVolumeResponse{
-			CapacityBytes: 0,
-		} */
 		expandVolumeResp.NodeExpansionRequired = nodeExpansionRequired
 		return expandVolumeResp, nil
 	}

--- a/test/unit-test/run.sh
+++ b/test/unit-test/run.sh
@@ -14,8 +14,9 @@
 # This will run coverage analysis using the integration testing.
 # The env.sh must point to a valid Unity XT Array# on this system.
 
-rm -f /root/go/bin/csi.sock
+
 source ../../env.sh
+mkdir $(dirname "${CSI_ENDPOINT}") || rm -f ${CSI_ENDPOINT}
 echo $SDC_GUID
 go test -v -coverprofile=c.out -timeout 60m -coverpkg=github.com/dell/csi-unity/service *test.go &
 wait 


### PR DESCRIPTION
# Description
ControllerExpandVolume function in idempotency path change capacity to 0 and it cause error. This change fix capacity value after resize to lower capacity.

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Backward compatibility is not broken

# Test:
- [x] Unit test 
