### PR TITLE
fix: register worker nodes on the Unity array

### DIFF
--- a/service/node.go
+++ b/service/node.go
@@ -1522,7 +1522,7 @@ func (s *service) addNodeInformationIntoArray(ctx context.Context, array *Storag
 		log.Infof("Node %s does not have FC or iSCSI initiators and can only be used for NFS exports", s.opts.NodeName)
 	}
 
-	nodeIps, err := utils.GetHostIP()
+	nodeIps, err := utils.GetHostIP(ctx)
 	if err != nil {
 		return status.Error(codes.Unknown, utils.GetMessageWithRunID(rid, "Unable to get node IP. Error: %v", err))
 	}

--- a/service/utils/emcutils.go
+++ b/service/utils/emcutils.go
@@ -145,7 +145,8 @@ func GetFCInitiators(ctx context.Context) ([]string, error) {
 }
 
 // GetHostIP - Utility method to extract Host IP
-func GetHostIP() ([]string, error) {
+func GetHostIP(ctx context.Context) ([]string, error) {
+	log := GetRunidLogger(ctx)
 	cmd := exec.Command("hostname", "-I")
 	cmdOutput := &bytes.Buffer{}
 	cmd.Stdout = cmdOutput
@@ -161,8 +162,10 @@ func GetHostIP() ([]string, error) {
 	}
 	output := string(cmdOutput.Bytes())
 	ips := strings.Split(strings.TrimSpace(output), " ")
+	log.Debugf("Host IPs: %v", ips)
 
 	hostname, err := os.Hostname()
+	log.Debugf("Hostname: %v", hostname)
 	if err != nil {
 		return nil, err
 	}
@@ -171,8 +174,10 @@ func GetHostIP() ([]string, error) {
 	for _, ip := range ips {
 		if !strings.Contains(ip, ":") {
 			lookupResp, err := net.LookupAddr(ip)
+			log.Debugf("lookupResp: %v for ip: %v", lookupResp, ip)
 			if err == nil {
 				for _, resp := range lookupResp {
+					log.Debugf("resp: %v, hostname: %v", resp, hostname)
 					if strings.Contains(resp, hostname) {
 						lookupIps = append(lookupIps, ip)
 					}

--- a/service/utils/emcutils.go
+++ b/service/utils/emcutils.go
@@ -172,7 +172,7 @@ func GetHostIP() ([]string, error) {
 		lookupResp, err := net.LookupAddr(ip)
 		if err == nil {
 			for _, resp := range lookupResp {
-				if strings.Contains(resp, hostname) {
+				if strings.Contains(resp, hostname) && !strings.Contains(resp, ":") {
 					lookupIps = append(lookupIps, ip)
 				}
 			}

--- a/service/utils/emcutils.go
+++ b/service/utils/emcutils.go
@@ -170,12 +170,16 @@ func GetHostIP() ([]string, error) {
 	var lookupIps []string
 	for _, ip := range ips {
 		lookupResp, err := net.LookupAddr(ip)
-		if err == nil && strings.Contains(lookupResp[0], hostname) {
-			lookupIps = append(lookupIps, ip)
+		if err == nil {
+			for _, resp := range lookupResp {
+				if strings.Contains(resp, hostname) {
+					lookupIps = append(lookupIps, ip)
+				}
+			}
 		}
 	}
 	if len(lookupIps) == 0 {
-		lookupIps = append(lookupIps, ips[0])
+		return nil, errors.New("host ip not found")
 	}
 	return lookupIps, nil
 }

--- a/service/utils/emcutils.go
+++ b/service/utils/emcutils.go
@@ -169,11 +169,13 @@ func GetHostIP() ([]string, error) {
 
 	var lookupIps []string
 	for _, ip := range ips {
-		lookupResp, err := net.LookupAddr(ip)
-		if err == nil {
-			for _, resp := range lookupResp {
-				if strings.Contains(resp, hostname) && !strings.Contains(resp, ":") {
-					lookupIps = append(lookupIps, ip)
+		if !strings.Contains(ip, ":") {
+			lookupResp, err := net.LookupAddr(ip)
+			if err == nil {
+				for _, resp := range lookupResp {
+					if strings.Contains(resp, hostname) {
+						lookupIps = append(lookupIps, ip)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
# Description
Fixing worker nodes registration on the Unity array - modifying function `GetHostIP()`.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] Integration tests via csm-pipeline
