### PR TITLE
go version bump-up

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dell/csi-unity
 
-go 1.21
+go 1.22
 
 require (
 	github.com/container-storage-interface/spec v1.6.0


### PR DESCRIPTION
Updating go version to latest available i.e. => 1.22