### PR TITLE
Fetch host ip when lookup address fails 

### DIFF
--- a/service/utils/emcutils.go
+++ b/service/utils/emcutils.go
@@ -145,6 +145,7 @@ func GetFCInitiators(ctx context.Context) ([]string, error) {
 
 // GetHostIP - Utility method to extract Host IP
 func GetHostIP() ([]string, error) {
+	// @TODO: Investigate the use of 'hostname -I' fetching all the addresses of the host
 	cmd := exec.Command("hostname", "-I")
 	cmdOutput := &bytes.Buffer{}
 	cmd.Stdout = cmdOutput
@@ -174,6 +175,16 @@ func GetHostIP() ([]string, error) {
 		}
 	}
 	if len(lookupIps) == 0 {
+		// Compute host ip from 'hostname -i' when lookup address fails
+		cmd = exec.Command("hostname", "-i")
+		cmdOutput = &bytes.Buffer{}
+		cmd.Stdout = cmdOutput
+		err = cmd.Run()
+		if err != nil {
+			return nil, err
+		}
+		output := string(cmdOutput.Bytes())
+		ips := strings.Split(strings.TrimSpace(output), " ")
 		lookupIps = append(lookupIps, ips[0])
 	}
 	return lookupIps, nil


### PR DESCRIPTION
# Description
This PR adds logic to fetch the host ip using `hostname -i` command when lookup address fails. With this change, correct host address is getting added to the NFS export list and mount is success.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1306 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Verified by creating an NFS test pod consuming the file system, mount was successful, and pod went into Running state.
