### PR TITLE
update logic for GetHostIP and allowedNetworks

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -263,7 +263,12 @@ func (s *service) BeforeServe(
 
 	var networksList []string
 	if allNetworks, ok := csictx.LookupEnv(ctx, EnvAllowedNetworks); ok {
-		networksList = strings.Split(allNetworks, " ")
+		allNetworks = strings.TrimSpace(allNetworks)
+		if allNetworks == "" {
+			networksList = []string{}
+		} else {
+			networksList = strings.Split(allNetworks, ",")
+		}
 	}
 	opts.allowedNetworks = networksList
 

--- a/service/utils/emcutils.go
+++ b/service/utils/emcutils.go
@@ -174,6 +174,16 @@ func GetHostIP() ([]string, error) {
 		}
 	}
 	if len(lookupIps) == 0 {
+		// Compute host ip from 'hostname -i' when lookup address fails
+		cmd = exec.Command("hostname", "-i")
+		cmdOutput = &bytes.Buffer{}
+		cmd.Stdout = cmdOutput
+		err = cmd.Run()
+		if err != nil {
+			return nil, err
+		}
+		output := string(cmdOutput.Bytes())
+		ips := strings.Split(strings.TrimSpace(output), " ")
 		lookupIps = append(lookupIps, ips[0])
 	}
 	return lookupIps, nil
@@ -197,6 +207,7 @@ func GetAddresses(allowedNetworks []string, addrs []net.Addr) ([]string, error) 
 	var nodeIPs []string
 	networks := make(map[string]bool)
 	for _, cnet := range allowedNetworks {
+		cnet = strings.TrimSpace(cnet)
 		_, cnet, err := net.ParseCIDR(cnet)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# Description
This PR addresses the following:

- Update logic to read env EnvAllowedNetworks handling the case when its empty
- Update logic for GetHostIP()

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1335 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested with CIDR address in allowedNetworks
![image](https://github.com/dell/csi-unity/assets/109594002/cf641153-cc03-456d-ba7b-1bf6626f5e1a)

- [x] Tested with empty address in allowedNetworks
![image](https://github.com/dell/csi-unity/assets/109594002/bfc1b702-8374-4c9b-8515-0be500957367)

