### PR TITLE
Added no cache buildAdded make target to build without cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,14 @@ podman-push: download-csm-common go-build
 	$(eval include csm-common.mk)
 	sh build.sh --baseubi $(DEFAULT_BASEIMAGE) --goimage $(DEFAULT_GOIMAGE) --push
 
+podman-build-no-cache: download-csm-common go-build
+	$(eval include csm-common.mk)
+	sh build.sh --baseubi $(DEFAULT_BASEIMAGE) --goimage $(DEFAULT_GOIMAGE) --no-cache
+
+podman-no-cachepush: download-csm-common go-build
+	$(eval include csm-common.mk)
+	sh build.sh --baseubi $(DEFAULT_BASEIMAGE) --goimage $(DEFAULT_GOIMAGE) --push --no-cache
+
 #
 # Docker-related tasks
 #

--- a/build.sh
+++ b/build.sh
@@ -34,7 +34,7 @@ function build_image {
    echo ${DEFAULT_GOIMAGE}
    bash build_ubi_micro.sh ${BASE_UBI_IMAGE}
    echo $BUILDCMD build -t ${IMAGE_NAME}:${IMAGE_TAG} .
-   (cd .. && $BUILDCMD build -t ${IMAGE_NAME}:${IMAGE_TAG} --build-arg GOIMAGE=$DEFAULT_GOIMAGE --build-arg GOPROXY=$GOPROXY -f csi-unity/Dockerfile.podman . --format=docker)
+   (cd .. && $BUILDCMD build ${NOCACHE} -t ${IMAGE_NAME}:${IMAGE_TAG} --build-arg GOIMAGE=$DEFAULT_GOIMAGE --build-arg GOPROXY=$GOPROXY -f csi-unity/Dockerfile.podman . --format=docker)
    echo $BUILDCMD tag ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_REPO}/${IMAGE_REPO_NAMESPACE}/${IMAGE_NAME}:${IMAGE_TAG}
    $BUILDCMD tag ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_REPO}/${IMAGE_REPO_NAMESPACE}/${IMAGE_NAME}:${IMAGE_TAG}
 }
@@ -51,6 +51,7 @@ BIN_NAME=${NAME}
 IMAGE_REPO=dellemc
 IMAGE_REPO_NAMESPACE=csi-unity
 IMAGE_TAG=${IMAGE_TAG:-$(date +%Y%m%d%H%M%S)}
+NOCACHE=
 
 # Read options
 for param in $*; do
@@ -69,6 +70,10 @@ for param in $*; do
     shift
     PUSH_IMAGE='true'
     ;;
+  "--no-cache")
+      shift
+      NOCACHE='--no-cache'
+      ;;
   esac
 done
 

--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,7 @@ function build_image {
    echo ${BASE_UBI_IMAGE}
    echo ${DEFAULT_GOIMAGE}
    bash build_ubi_micro.sh ${BASE_UBI_IMAGE}
-   echo $BUILDCMD build -t ${IMAGE_NAME}:${IMAGE_TAG} .
+   echo $BUILDCMD build ${NOCACHE} -t ${IMAGE_NAME}:${IMAGE_TAG} .
    (cd .. && $BUILDCMD build ${NOCACHE} -t ${IMAGE_NAME}:${IMAGE_TAG} --build-arg GOIMAGE=$DEFAULT_GOIMAGE --build-arg GOPROXY=$GOPROXY -f csi-unity/Dockerfile.podman . --format=docker)
    echo $BUILDCMD tag ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_REPO}/${IMAGE_REPO_NAMESPACE}/${IMAGE_NAME}:${IMAGE_TAG}
    $BUILDCMD tag ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_REPO}/${IMAGE_REPO_NAMESPACE}/${IMAGE_NAME}:${IMAGE_TAG}
@@ -71,9 +71,9 @@ for param in $*; do
     PUSH_IMAGE='true'
     ;;
   "--no-cache")
-      shift
-      NOCACHE='--no-cache'
-      ;;
+    shift
+    NOCACHE='--no-cache'
+    ;;
   esac
 done
 

--- a/service/controller.go
+++ b/service/controller.go
@@ -205,6 +205,7 @@ func (s *service) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest
 
 		log.Debug("Filesystem does not exist, proceeding to create new filesystem")
 		// Hardcoded ProtocolNFS to 0 in order to support only NFS
+		// #nosec G115
 		resp, err := fileAPI.CreateFilesystem(ctx, volName, storagePool, desc, nasServer, uint64(size), int(tieringPolicy), int(hostIoSize), ProtocolNFS, thin, dataReduction)
 		// Add method to create filesystem
 		if err != nil {
@@ -261,6 +262,7 @@ func (s *service) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest
 		}
 
 		log.Debug("Volume does not exist, proceeding to create new volume")
+		// #nosec G115
 		resp, err := volumeAPI.CreateLun(ctx, volName, storagePool, desc, uint64(size), int(tieringPolicy), hostIOLimitID, thin, dataReduction)
 		if err != nil {
 			return nil, status.Error(codes.Unknown, utils.GetMessageWithRunID(rid, "Create Volume %s failed with error: %v", volName, err))
@@ -831,12 +833,14 @@ func (s *service) ControllerExpandVolume(ctx context.Context, req *csi.Controlle
 		}
 
 		// Idempotency check
+		// #nosec G115
 		if filesystem.FileContent.SizeTotal >= uint64(capacity) {
 			log.Infof("New Filesystem size (%d) is lower or same as existing Filesystem size. Ignoring expand volume operation.", filesystem.FileContent.SizeTotal)
 			expandVolumeResp.NodeExpansionRequired = false
 			return expandVolumeResp, nil
 		}
 
+		// #nosec G115
 		err = filesystemAPI.ExpandFilesystem(ctx, volID, uint64(capacity))
 		if err != nil {
 			return nil, status.Error(codes.Unknown, utils.GetMessageWithRunID(rid, "Expand filesystem failed with error: %v", err))


### PR DESCRIPTION
# Description
Image build job fails because of no space left on the build machine. This is caused by overlay images created during the build process

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1448 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested build and there are no overlay containers left mounted on the build machine
