### PR TITLE
K8s and OCP version update

### DIFF
--- a/dell-csi-helm-installer/verify-csi-unity.sh
+++ b/dell-csi-helm-installer/verify-csi-unity.sh
@@ -11,7 +11,7 @@
 # verify-csi-unity method
 function verify-csi-unity() {
   verify_k8s_versions "1.25" "1.31"
-  verify_openshift_versions "4.15" "4.16"
+  verify_openshift_versions "4.16" "4.17"
   verify_namespace "${NS}"
   verify_required_secrets "${RELEASE}-creds"
   verify_optional_secrets "${RELEASE}-certs"

--- a/dell-csi-helm-installer/verify-csi-unity.sh
+++ b/dell-csi-helm-installer/verify-csi-unity.sh
@@ -10,7 +10,7 @@
 
 # verify-csi-unity method
 function verify-csi-unity() {
-  verify_k8s_versions "1.24" "1.30"
+  verify_k8s_versions "1.25" "1.31"
   verify_openshift_versions "4.15" "4.16"
   verify_namespace "${NS}"
   verify_required_secrets "${RELEASE}-creds"

--- a/service/controller.go
+++ b/service/controller.go
@@ -205,7 +205,7 @@ func (s *service) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest
 
 		log.Debug("Filesystem does not exist, proceeding to create new filesystem")
 		// Hardcoded ProtocolNFS to 0 in order to support only NFS
-		resp, err := fileAPI.CreateFilesystem(ctx, volName, storagePool, desc, nasServer, uint64(size), int(tieringPolicy), int(hostIoSize), ProtocolNFS, thin, dataReduction)
+		resp, err := fileAPI.CreateFilesystem(ctx, volName, storagePool, desc, nasServer, uint64(size), int(tieringPolicy), int(hostIoSize), ProtocolNFS, thin, dataReduction) // #nosec G115 - This is a false positive
 		// Add method to create filesystem
 		if err != nil {
 			log.Debugf("Filesystem create response:%v Error:%v", resp, err)
@@ -261,7 +261,7 @@ func (s *service) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest
 		}
 
 		log.Debug("Volume does not exist, proceeding to create new volume")
-		resp, err := volumeAPI.CreateLun(ctx, volName, storagePool, desc, uint64(size), int(tieringPolicy), hostIOLimitID, thin, dataReduction)
+		resp, err := volumeAPI.CreateLun(ctx, volName, storagePool, desc, uint64(size), int(tieringPolicy), hostIOLimitID, thin, dataReduction) // #nosec G115 - This is a false positive
 		if err != nil {
 			return nil, status.Error(codes.Unknown, utils.GetMessageWithRunID(rid, "Create Volume %s failed with error: %v", volName, err))
 		}
@@ -831,13 +831,13 @@ func (s *service) ControllerExpandVolume(ctx context.Context, req *csi.Controlle
 		}
 
 		// Idempotency check
-		if filesystem.FileContent.SizeTotal >= uint64(capacity) {
+		if filesystem.FileContent.SizeTotal >= uint64(capacity) { // #nosec G115 - This is a false positive
 			log.Infof("New Filesystem size (%d) is lower or same as existing Filesystem size. Ignoring expand volume operation.", filesystem.FileContent.SizeTotal)
 			expandVolumeResp.NodeExpansionRequired = false
 			return expandVolumeResp, nil
 		}
 
-		err = filesystemAPI.ExpandFilesystem(ctx, volID, uint64(capacity))
+		err = filesystemAPI.ExpandFilesystem(ctx, volID, uint64(capacity)) // #nosec G115 - This is a false positive
 		if err != nil {
 			return nil, status.Error(codes.Unknown, utils.GetMessageWithRunID(rid, "Expand filesystem failed with error: %v", err))
 		}

--- a/service/controller.go
+++ b/service/controller.go
@@ -831,7 +831,7 @@ func (s *service) ControllerExpandVolume(ctx context.Context, req *csi.Controlle
 		}
 
 		// Idempotency check
-		if filesystem.FileContent.SizeTotal >= uint64(capacity) { // #nosec G115 - This is a false positive
+		if filesystem.FileContent.SizeTotal >= uint64(capacity) /* #nosec G115 -- This is a false positive */ {
 			log.Infof("New Filesystem size (%d) is lower or same as existing Filesystem size. Ignoring expand volume operation.", filesystem.FileContent.SizeTotal)
 			expandVolumeResp.NodeExpansionRequired = false
 			return expandVolumeResp, nil


### PR DESCRIPTION
# Description
K8s version from 1.30 to 1.31 and OCP version update from 4.16 to 4.17

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|dell/csm#1435|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
